### PR TITLE
fix: $member-match response bundle without identifier internal error

### DIFF
--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match.rb
@@ -158,8 +158,7 @@ module DaVinciPDexTestKit
             assert_valid_json(response[:body])
             assert_resource_type('Bundle')
 
-            # XXX skip or fail? this is not formally part of the spec
-            skip "Bundle has no Patient resource." unless resource.entry.find{ |entry| entry.resource&.resourceType == 'Patient' }
+            assert resource.entry.find{ |entry| entry.resource&.resourceType == 'Patient' }, "Bundle has no Patient resource."
 
             patient_id = resource.entry.reverse_each.find{ |entry| entry.resource&.resourceType == 'Patient' }&.resource&.id
             assert patient_id, "Patient resource in Bundle has no logical resource id"


### PR DESCRIPTION
# Summary

This is a fix in response to client tests running against server tests, where a $member-match response without Patient identifier caused an internal error on server side tests. This is now fixed, and in general the code was made more robust. 

# Testing Guidance

This is hard to test without it being merged to @360dgries' latest branch. I ran the server side tests with preset information and it ran successfully.
