### PR TITLE
FI-2826 Link Substitution fix

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
 INFERNO_HOST=http://localhost
 REDIS_URL=redis://redis:6379/0
 VALIDATOR_URL=http://validator_service:4567
-FHIR_REFERENCE_SERVER=http://host.docker.internal:8080/reference-server/r4/
+FHIR_REFERENCE_SERVER=http://host.docker.internal:8080/reference-server/r4

--- a/lib/davinci_pdex_test_kit/docs/payer_client_suite_description_v200.md
+++ b/lib/davinci_pdex_test_kit/docs/payer_client_suite_description_v200.md
@@ -71,9 +71,6 @@ to make requests against Inferno for these tests. To use the Postman demo on thi
    use Postman to send some or all of the requests in the `Clinical Data Requests` folder and click
    on the link in the dialog when done. If not all the requests are made, the test will not pass 
    because the test requires that all available data be accessed.
-6. When a third `User Action Required` requesting additional `$member-match` requests be made
-   demonstrating coverage of all must support elements on `$member-match` submissions, use Postman to send any or all of the requests found in the `$member-match Requests` folder. If only the 
-   `$member-match missing CoverageToMatch` is sent, then the test will fail due to missing examples.
 
 The tests will complete and the results made available for review.
 


### PR DESCRIPTION
Removed the 6th step in the suite description as those tests are no longer part of the kit (for now)

Updated the link substitution, tested on both prod and development to make sure it accurately replaces the links in `bundle.link` and `resource.fullURL`.  It pulls from the links in the `.env` files, so should work on QA as well as long as there is a QA `.env`



