### PR TITLE
Patient ID fix

### DIFF
--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/patient_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/patient_clinical_data_request_test.rb
@@ -17,7 +17,7 @@ module DaVinciPDexTestKit
     run do
       skip_if scratch[:Patient].nil?, "No requests made for Patient resources"
 
-      assert scratch[:Patient].any? {|resource| resource.id == 'pdex-Patient'}, "Unable to find expected resource: 999" 
+      assert scratch[:Patient].any? {|resource| resource.id == '999'}, "Unable to find expected resource: 999" 
     end
   end
 end


### PR DESCRIPTION
Fixing patient test to check for `999` instead of `pdex-Patient` for the assertion

