### PR TITLE
increase wait timeout

### DIFF
--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/initial_wait_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/initial_wait_test.rb
@@ -23,7 +23,8 @@ module DaVinciPDexTestKit
           * $export-poll-status: `#{export_status_url}`, then continue to make reads from the binaries if a payload is delivered
           
           and [click here](#{resume_clinical_data_url}?token=#{access_token}) when done.
-        )
+        ),
+        timeout: 900
       )
     end
   end


### PR DESCRIPTION
# Summary

Increase wait timeout for PDex client test clinical data requests from 5 to 15 minutes

# Testing Guidance

- start the client test suite
- use the postman preset and start the tests
- submit a $member-match request
- Once the next wait dialog appears for clinical tests, wait for 6 minutes before clicking continue. The test should still resume correctly (all skips since no data was provided)