### PR TITLE
Bump uscore 0.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     davinci_pdex_test_kit (0.10.4)
       bulk_data_test_kit (~> 0.10)
       inferno_core (~> 0.4.38)
-      us_core_test_kit (~> 0.7.1)
+      us_core_test_kit (~> 0.8)
 
 GEM
   remote: https://rubygems.org/
@@ -316,7 +316,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
-    us_core_test_kit (0.7.2)
+    us_core_test_kit (0.8.0)
       inferno_core (>= 0.4.37)
       smart_app_launch_test_kit (>= 0.4.0)
       tls_test_kit (~> 0.2.0)

--- a/davinci_pdex_test_kit.gemspec
+++ b/davinci_pdex_test_kit.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inferno-framework/davinci-pdex-test-kit/'
   spec.license       = 'Apache-2.0'
   spec.add_runtime_dependency 'inferno_core', '~> 0.4.38'
-  spec.add_runtime_dependency 'us_core_test_kit', '~> 0.7.1'
+  spec.add_runtime_dependency 'us_core_test_kit', '~> 0.8'
   spec.add_runtime_dependency 'bulk_data_test_kit', '~> 0.10'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/metadata.yml
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/metadata.yml
@@ -230,19 +230,32 @@
       :type: requiredBinding
       :path: category
       :values:
-      - submitted
-      - copay
-      - eligible
-      - deductible
-      - benefit
-      - coinsurance
-      - noncovered
-      - priorpayerpaid
-      - paidbypatient
-      - paidtopatient
-      - paidtoprovider
-      - memberliability
-      - discount
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: submitted
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: copay
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: eligible
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: deductible
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: benefit
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: coinsurance
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: noncovered
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: priorpayerpaid
+      - :sysstem: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: paidbypatient
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: paidtopatient
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: paidtoprovider
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: memberliability
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: discount
   - :slice_id: ExplanationOfBenefit.item.adjudication:allowedunits
     :slice_name: allowedunits
     :path: item.adjudication
@@ -277,19 +290,32 @@
       :type: requiredBinding
       :path: category
       :values:
-      - submitted
-      - copay
-      - eligible
-      - deductible
-      - benefit
-      - coinsurance
-      - noncovered
-      - priorpayerpaid
-      - paidbypatient
-      - paidtopatient
-      - paidtoprovider
-      - memberliability
-      - discount
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: submitted
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: copay
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: eligible
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: deductible
+      - :system: http://terminology.hl7.org/5.0.0/CodeSystem-adjudication
+        :code: benefit
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: coinsurance
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: noncovered
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: priorpayerpaid
+      - :sysstem: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: paidbypatient
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: paidtopatient
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: paidtoprovider
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: memberliability
+      - :system: https://hl7.org/fhir/us/davinci-pdex/STU2/CodeSystem-PDexAdjudicationCS
+        :code: discount
   - :slice_id: ExplanationOfBenefit.adjudication:denialreason
     :slice_name: denialreason
     :path: adjudication


### PR DESCRIPTION
# Summary

Adapt ExplanationOfBenefit metadata.yml to work with us-core-test-kit PR 191: 
https://github.com/inferno-framework/us-core-test-kit/pull/191

# Testing

Behavior is same between main branch and this branch, using FHIR Foundry preset
