### PR TITLE
Prefix all ids with pdex to prevent id conflict

### DIFF
--- a/lib/davinci_pdex_test_kit/pdex_payer_client/client_member_match_tests/client_member_match_submit_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/client_member_match_tests/client_member_match_submit_test.rb
@@ -4,7 +4,7 @@ module DaVinciPDexTestKit
   class PDexClientMemberMatchSubmitTest < Inferno::Test
     include URLs
 
-    id :initial_member_match_submit_test
+    id :pdex_initial_member_match_submit_test
     title 'Client makes a $member-match request'
     description %(
       This test will await a $member-match request and proceed once a request is received.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/client_member_match_tests/client_member_match_validation_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/client_member_match_tests/client_member_match_validation_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     include DaVinciPDexTestKit::ClientValidationTest
     include URLs
 
-    id :initial_member_match_validation_test
+    id :pdex_initial_member_match_validation_test
     title 'Client provides a valid $member-match request'
     description %(
       This test will validate the received $member-match-request input, ensuring it corresponds to the [HRex member-match-in profile](http://hl7.org/fhir/us/davinci-hrex/StructureDefinition/hrex-parameters-member-match-in)

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/client_must_support_tests/client_member_match_must_support_submit_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/client_must_support_tests/client_member_match_must_support_submit_test.rb
@@ -4,7 +4,7 @@ module DaVinciPDexTestKit
   class PDexClientMemberMatchMustSupportSubmitTest < Inferno::Test
     include URLs
 
-    id :initial_member_match_must_support_submit_test
+    id :pdex_initial_member_match_must_support_submit_test
     title '$member-match requests span all Must Supports'
     description %(
       This test will receive $member-match requests until the user specifies they are done.  It then checks all received $member-match requests for Must Support coverage.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/client_must_support_tests/client_member_match_must_support_validation_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/client_must_support_tests/client_member_match_must_support_validation_test.rb
@@ -7,7 +7,7 @@ module DaVinciPDexTestKit
     include DaVinciPDexTestKit::ClientValidationTest
     include URLs
 
-    id :initial_member_match_must_support_validation_test
+    id :pdex_initial_member_match_must_support_validation_test
     title 'All must support elements are provided in the received $member-match requests'
     description %(
       This test verifies that the client is capable of making $member-match requests 

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/allergyintolerance_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/allergyintolerance_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :allergyintolerance_clinical_data_request_test
+    id :pdex_allergyintolerance_clinical_data_request_test
     title 'AllergyIntolerance resources related to the patient matched are gathered'
     description %(
       This test will look through all returned AllergyIntolerance resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/careplan_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/careplan_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :careplan_clinical_data_request_test
+    id :pdex_careplan_clinical_data_request_test
     title 'CarePlan resources related to the patient matched are gathered'
     description %(
       This test will look through all returned CarePlan resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/careteam_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/careteam_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :careteam_clinical_data_request_test
+    id :pdex_careteam_clinical_data_request_test
     title 'CareTeam resources related to the patient matched are gathered'
     description %(
       This test will look through all returned CareTeam resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/condition_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/condition_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :condition_clinical_data_request_test
+    id :pdex_condition_clinical_data_request_test
     title 'Condition resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Condition resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/device_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/device_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :device_clinical_data_request_test
+    id :pdex_device_clinical_data_request_test
     title 'Device resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Device resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/diagnosticreport_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/diagnosticreport_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :diagnosticreport_clinical_data_request_test
+    id :pdex_diagnosticreport_clinical_data_request_test
     title 'DiagnosticReport resources related to the patient matched are gathered'
     description %(
       This test will look through all returned DiagnosticReport resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/documentreference_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/documentreference_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :documentreference_clinical_data_request_test
+    id :pdex_documentreference_clinical_data_request_test
     title 'DocumentReference resources related to the patient matched are gathered'
     description %(
       This test will look through all returned DocumentReference resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/encounter_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/encounter_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :encounter_clinical_data_request_test
+    id :pdex_encounter_clinical_data_request_test
     title 'Encounter resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Encounter resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/explanationofbenefit_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/explanationofbenefit_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :explanationofbenefit_clinical_data_request_test
+    id :pdex_explanationofbenefit_clinical_data_request_test
     title 'ExplanationOfBenefit resources related to the patient matched are gathered'
     description %(
       This test will look through all returned ExplanationOfBenefit resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/goal_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/goal_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :goal_clinical_data_request_test
+    id :pdex_goal_clinical_data_request_test
     title 'Goal resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Goal resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/immunization_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/immunization_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :immunization_clinical_data_request_test
+    id :pdex_immunization_clinical_data_request_test
     title 'Immunization resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Immunization resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/initial_scratch_storing.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/initial_scratch_storing.rb
@@ -3,7 +3,7 @@ module DaVinciPDexTestKit
   class PDexClientScratchStorage < Inferno::Test
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :initial_scratch_storing
+    id :pdex_initial_scratch_storing
     title 'Client makes clinical data requests that capture an entire patient'
     description %(
       This test organizes the received requests in order to validate all expected specific resources were returned

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/initial_wait_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/initial_wait_test.rb
@@ -3,7 +3,7 @@ module DaVinciPDexTestKit
   class PDexClientSubmitMustSupportTest < Inferno::Test
     include URLs
 
-    id :initial_wait_test
+    id :pdex_initial_wait_test
     title 'Client makes clinical data requests'
     description %(
       This test will receive clinical data requests until the user confirms they are done. 

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/location_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/location_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :location_clinical_data_request_test
+    id :pdex_location_clinical_data_request_test
     title 'Location resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Location resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/medicationdispense_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/medicationdispense_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :medicationdispense_clinical_data_request_test
+    id :pdex_medicationdispense_clinical_data_request_test
     title 'MedicationDispense resources related to the patient matched are gathered'
     description %(
       This test will look through all returned MedicationDispense resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/medicationrequest_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/medicationrequest_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :medicationrequest_clinical_data_request_test
+    id :pdex_medicationrequest_clinical_data_request_test
     title 'MedicationRequest resources related to the patient matched are gathered'
     description %(
       This test will look through all returned MedicationRequest resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/observation_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/observation_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :observation_clinical_data_request_test
+    id :pdex_observation_clinical_data_request_test
     title 'Observation resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Observation resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/organization_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/organization_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :organization_clinical_data_request_test
+    id :pdex_organization_clinical_data_request_test
     title 'Organization resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Organization resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/patient_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/patient_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :patient_clinical_data_request_test
+    id :pdex_patient_clinical_data_request_test
     title 'Patient resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Patient resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/practitioner_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/practitioner_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :practitioner_clinical_data_request_test
+    id :pdex_practitioner_clinical_data_request_test
     title 'Practitioner resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Practitioner resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/practitionerrole_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/practitionerrole_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :practitionerrole_clinical_data_request_test
+    id :pdex_practitionerrole_clinical_data_request_test
     title 'PractitionerRole resources related to the patient matched are gathered'
     description %(
       This test will look through all returned PractitionerRole resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/procedure_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/procedure_clinical_data_request_test.rb
@@ -6,7 +6,7 @@ module DaVinciPDexTestKit
     include URLs
     include DaVinciPDexTestKit::ClientValidationTest
 
-    id :procedure_clinical_data_request_test
+    id :pdex_procedure_clinical_data_request_test
     title 'Procedure resources related to the patient matched are gathered'
     description %(
       This test will look through all returned Procedure resources for a specific expected resource related to the matched patient.

--- a/lib/davinci_pdex_test_kit/pdex_payer_client_suite.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client_suite.rb
@@ -143,33 +143,33 @@ module DaVinciPDexTestKit
         title "Workflow Tests"
         group do
           title "$member-match validation"
-          test from: :initial_member_match_submit_test
-          test from: :initial_member_match_validation_test
+          test from: :pdex_initial_member_match_submit_test
+          test from: :pdex_initial_member_match_validation_test
         end
         group do
           title "Clinical data request tests"
-          test from: :initial_wait_test
-          test from: :initial_scratch_storing
-          test from: :allergyintolerance_clinical_data_request_test
-          test from: :careplan_clinical_data_request_test
-          test from: :careteam_clinical_data_request_test
-          test from: :condition_clinical_data_request_test
-          test from: :device_clinical_data_request_test
-          test from: :diagnosticreport_clinical_data_request_test
-          test from: :documentreference_clinical_data_request_test
-          test from: :encounter_clinical_data_request_test
-          test from: :explanationofbenefit_clinical_data_request_test
-          test from: :goal_clinical_data_request_test
-          test from: :immunization_clinical_data_request_test
-          test from: :location_clinical_data_request_test
-          test from: :medicationdispense_clinical_data_request_test
-          test from: :medicationrequest_clinical_data_request_test
-          test from: :observation_clinical_data_request_test
-          test from: :organization_clinical_data_request_test
-          test from: :patient_clinical_data_request_test
-          test from: :practitioner_clinical_data_request_test
-          test from: :practitionerrole_clinical_data_request_test
-          test from: :procedure_clinical_data_request_test
+          test from: :pdex_initial_wait_test
+          test from: :pdex_initial_scratch_storing
+          test from: :pdex_allergyintolerance_clinical_data_request_test
+          test from: :pdex_careplan_clinical_data_request_test
+          test from: :pdex_careteam_clinical_data_request_test
+          test from: :pdex_condition_clinical_data_request_test
+          test from: :pdex_device_clinical_data_request_test
+          test from: :pdex_diagnosticreport_clinical_data_request_test
+          test from: :pdex_documentreference_clinical_data_request_test
+          test from: :pdex_encounter_clinical_data_request_test
+          test from: :pdex_explanationofbenefit_clinical_data_request_test
+          test from: :pdex_goal_clinical_data_request_test
+          test from: :pdex_immunization_clinical_data_request_test
+          test from: :pdex_location_clinical_data_request_test
+          test from: :pdex_medicationdispense_clinical_data_request_test
+          test from: :pdex_medicationrequest_clinical_data_request_test
+          test from: :pdex_observation_clinical_data_request_test
+          test from: :pdex_organization_clinical_data_request_test
+          test from: :pdex_patient_clinical_data_request_test
+          test from: :pdex_practitioner_clinical_data_request_test
+          test from: :pdex_practitionerrole_clinical_data_request_test
+          test from: :pdex_procedure_clinical_data_request_test
         end
       end
       
@@ -177,10 +177,10 @@ module DaVinciPDexTestKit
       #   title "Must Support validation"
       #   group do
       #     title "$member-match Must Support tests"
-      #     test from: :initial_member_match_must_support_submit_test
-      #     test from: :initial_member_match_must_support_validation_test
+      #     test from: :pdex_initial_member_match_must_support_submit_test
+      #     test from: :pdex_initial_member_match_must_support_validation_test
       #   end
       # end
     end
-  end
+end
   

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/export_patient_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/export_patient_group.rb
@@ -39,7 +39,8 @@ module DaVinciPDexTestKit
 
       output :patient_requires_access_token, :patient_status_output, :patient_bulk_download_url
 
-      test from: :patient_operation_in_capability_statement_validation,
+      test from: :pdex_patient_operation_in_capability_statement_validation,
+           id: :pdex_patient_export_in_capability_statement_test,
            title: 'Bulk Data Server declares support for Patient export operation in CapabilityStatement',
            config: {
              options: { operation_name: 'export', operation_url: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export' }

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/export_validation_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/export_validation_group.rb
@@ -36,7 +36,7 @@ module DaVinciPDexTestKit
           server SHALL be secured using Transport Layer Security  (TLS)
           Protocol Version 1.2 (RFC5246).
         DESCRIPTION
-        id :bulk_file_server_tls_version
+        id :pdex_bulk_file_server_tls_version
 
         config(
           inputs: { url: { name: :patient_bulk_download_url } },
@@ -45,7 +45,7 @@ module DaVinciPDexTestKit
       end
 
       test from: :bulk_data_valid_resources,
-           id: :bulk_data_patient_valid_resources,
+           id: :pdex_bulk_data_patient_valid_resources,
            config: {
              inputs: {
                status_output: { name: :patient_status_output },

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/multiple_member_matches_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/multiple_member_matches_group.rb
@@ -22,7 +22,7 @@ module DaVinciPDexTestKit
         group_config = { inputs: { member_match_request: { name: :multiple_member_match_request } } }
   
         test from: :pdex_member_match_request_profile_validation do
-          id :multiple_member_match_request_profile_test
+          id :pdex_multiple_member_match_request_profile_test
           config(group_config)
           title '[USER INPUT VALIDATION] Member match request for multiple matches is valid'
           description %{
@@ -41,7 +41,7 @@ module DaVinciPDexTestKit
         test from: :pdex_coverage_to_link_must_support_validation, config: group_config
 
         test do
-          id :member_match_has_multiple_matches
+          id :pdex_member_match_has_multiple_matches
           title 'Server $member-match operation returns 422 Unprocessable Content if multiple matches are found'
           description %{
             See [member matching logic](https://hl7.org/fhir/us/davinci-hrex/STU1/OperationDefinition-member-match.html#member-matching-logic)

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/no_member_matches_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/no_member_matches_group.rb
@@ -21,7 +21,7 @@ module DaVinciPDexTestKit
         group_config = { inputs: { member_match_request: { name: :no_member_match_request } } }
 
         test from: :pdex_member_match_request_profile_validation do
-          id :no_member_match_request_profile_test
+          id :pdex_no_member_match_request_profile_test
           config(group_config)
 
           title '[USER INPUT VALIDATION] Member match request for no matches is valid'
@@ -40,7 +40,7 @@ module DaVinciPDexTestKit
 
 
         test do
-          id :member_match_has_no_matches
+          id :pdex_member_match_has_no_matches
           title 'Server $member-match operation returns 422 Unprocessable Content if no matches are found'
           description %{
             See [member matching logic](https://hl7.org/fhir/us/davinci-hrex/STU1/OperationDefinition-member-match.html#member-matching-logic)

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/patient_operation_in_capability_statement_validation.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/patient_operation_in_capability_statement_validation.rb
@@ -27,7 +27,7 @@ module DaVinciPDexTestKit
     # Requires an Inferno fhir client configured.
     #
     class PatientOperationInCapabilityStatementValidation < Inferno::Test
-      id :patient_operation_in_capability_statement_validation
+      id :pdex_patient_operation_in_capability_statement_validation
 
       description %{
         The [CapabilityStatement](https://hl7.org/fhir/R4/capabilitystatement.html) must declare support for the

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_clinical_data_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_clinical_data_group.rb
@@ -26,7 +26,7 @@ module DaVinciPDexTestKit
         optional: true
 
       test do
-        id :workflow_clinical_encounter_query_test
+        id :pdex_workflow_clinical_encounter_query_test
         title 'Server can provide clinical Encounter data from matched member identifier'
         description %{
           Server receives request `GET [baseURL]/Encounter?subject=Patient/[id]` and returns 200.
@@ -44,7 +44,7 @@ module DaVinciPDexTestKit
       end
 
       test do
-        id :workflow_clinical_encounter_test
+        id :pdex_workflow_clinical_encounter_test
         title 'Server returned Search bundle with valid Encounter data'
         description %{
             Server returned search Bundle of Encounters with least 1 resource entry.

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_everything_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_everything_group.rb
@@ -27,7 +27,7 @@ module DaVinciPDexTestKit
         description: 'Manual Patient ID for testing Clinical Query and $everything $export without $member-match.',
         optional: true
 
-      test from: :patient_operation_in_capability_statement_validation,
+      test from: :pdex_patient_operation_in_capability_statement_validation,
            title: 'Server declares support for Patient everything operation in CapabilityStatement',
            config: {
              options: { operation_name: 'everything', operation_url: 'http://hl7.org/fhir/OperationDefinition/Patient-everything' }

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
@@ -43,15 +43,15 @@ module DaVinciPDexTestKit
         description: "A JSON payload for server's $member-match endpoint that has **exactly one match**",
         type: 'textarea'
 
-      test from: :patient_operation_in_capability_statement_validation,
-           id: :member_match_operation_in_capability_statement_test,
+      test from: :pdex_patient_operation_in_capability_statement_validation,
+           id: :pdex_member_match_operation_in_capability_statement_test,
            title: 'Server declares support for Patient member match operation in CapabilityStatement',
            config: {
              options: { operation_name: 'member-match', operation_url: 'http://hl7.org/fhir/us/davinci-hrex/OperationDefinition/member-match' }
            }
 
       test from: :pdex_member_match_request_profile_validation do
-        id :member_match_request_profile_test
+        id :pdex_member_match_request_profile_test
         title '[USER INPUT VALIDATION] Member match request for exactly one match is valid'
         description %{
           This test validates the conformity of the user input to the
@@ -62,7 +62,7 @@ module DaVinciPDexTestKit
       end
 
       test from: :pdex_member_match_request_local_references_validation do
-        id :member_match_request_local_references_test
+        id :pdex_member_match_request_local_references_test
         title '[USER INPUT VALIDATION] Member match request only uses local references'
       end
 
@@ -70,7 +70,7 @@ module DaVinciPDexTestKit
       test from: :pdex_coverage_to_link_must_support_validation
    
       test do
-        id :member_match_on_server_test
+        id :pdex_member_match_on_server_test
         title 'Server handles $member-match operation successfully'
         description 'Server receives request `POST [baseURL]/Patient/$member-match` and returns 200'
            
@@ -85,7 +85,7 @@ module DaVinciPDexTestKit
       end
   
       test do
-        id :member_match_response_profile_test
+        id :pdex_member_match_response_profile_test
         title 'Server $member-match response conforms to profile'
         description %{
           The response body from the previous POST request to $member-match must be valid FHIR JSON conforming to
@@ -111,7 +111,7 @@ module DaVinciPDexTestKit
       end
   
       test do
-        id :member_match_identifier_to_id
+        id :pdex_member_match_identifier_to_id
         title 'Server member identifier from $member-match yields logical Patient id'
         description %Q{
           The $member-match operation returns a Member Identifier, and subsequent clinical queries and operations

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
@@ -130,6 +130,9 @@ module DaVinciPDexTestKit
         run do
           skip_if !member_identifier, "No member identifier obtained from $member-match request"
  
+          # Delay because running the server suite on the client suite encounters a race condition
+          sleep(2)
+
           # We only query by identifier.value, and preset information happens to return a value with a system within it
           # which may be a bug.
           # Other options are to query by system|value or type-of:

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
@@ -130,9 +130,6 @@ module DaVinciPDexTestKit
         run do
           skip_if !member_identifier, "No member identifier obtained from $member-match request"
  
-          # Delay because running the server suite on the client suite encounters a race condition
-          sleep(2)
-
           # We only query by identifier.value, and preset information happens to return a value with a system within it
           # which may be a bug.
           # Other options are to query by system|value or type-of:


### PR DESCRIPTION
# Summary

Since inferno_core v0.5.0 disallows any duplicate ids, all ids are now prefixed with `pdex_`.

I also added a delay in one of the server tests to mitigate the race condition that occurs when the two test kits run against each other.

# Testing Guidance

1. Launch the PDex server test kit and make sure its tests loaded.
2. Launch the PDex client test kit and make sure its tests loaded.
3. Optionally: Use the "Preset for Client Tests" in the server test kit to run the two test kits against each other. Behavior should be identical to the one on https://inferno.healthit.gov.
