### PR TITLE
Shorten PDex IDs

### DIFF
--- a/lib/davinci_pdex_test_kit/pdex_payer_client/client_member_match_tests/client_member_match_validation_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/client_member_match_tests/client_member_match_validation_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexInitialMemberMatchValidationTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_initial_member_match_validation_test
+      id :pdex_initial_member_match_validation
       title 'Client provides a valid $member-match request'
       description %(
         This test will validate the received $member-match-request input, ensuring it corresponds to the

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/client_workflow_interaction_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/client_workflow_interaction_test.rb
@@ -2,7 +2,7 @@ module DaVinciPDexTestKit
   module PDexPayerClient
     class PDexClientWorkflowInteractionTest < Inferno::Test
   
-      id :pdex_client_workflow_interaction_test
+      id :pdex_client_workflow_interaction
       title 'Client makes requests to Inferno'
       description %(
         This test will await requests from the client under test to demonstrate

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/allergyintolerance_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/allergyintolerance_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientAllergyIntoleranceSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_allergyintolerance_clinical_data_request_test
+      id :pdex_allergyintolerance_clinical_data_request
       title 'AllergyIntolerance resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type AllergyIntollerance

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/careplan_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/careplan_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientCarePlanSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_careplan_clinical_data_request_test
+      id :pdex_careplan_clinical_data_request
       title 'CarePlan resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type CarePlan

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/careteam_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/careteam_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientCareTeamSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_careteam_clinical_data_request_test
+      id :pdex_careteam_clinical_data_request
       title 'CareTeam resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type CareTeam

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/clinical_data_request_check_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/clinical_data_request_check_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientClinicalDataRequestCheckTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_clinical_data_request_check_test
+      id :pdex_clinical_data_request_check
       title 'Check for Clinical Data Requests'
       description %(
         This test will check that clinical data requests were made and that

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/condition_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/condition_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientConditionSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_condition_clinical_data_request_test
+      id :pdex_condition_clinical_data_request
       title 'Condition resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Condition

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/device_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/device_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientDeviceSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_device_clinical_data_request_test
+      id :pdex_device_clinical_data_request
       title 'Device resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Device

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/diagnosticreport_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/diagnosticreport_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientDiagnosticReportSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_diagnosticreport_clinical_data_request_test
+      id :pdex_diagnosticreport_clinical_data_request
       title 'DiagnosticReport resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type DiagnosticReport

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/documentreference_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/documentreference_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientDocumentReferenceSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_documentreference_clinical_data_request_test
+      id :pdex_documentreference_clinical_data_request
       title 'DocumentReference resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type DocumentReference

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/encounter_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/encounter_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientEncounterSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_encounter_clinical_data_request_test
+      id :pdex_encounter_clinical_data_request
       title 'Encounter resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Encounter

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/explanationofbenefit_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/explanationofbenefit_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientExplanationOfBenefitSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_explanationofbenefit_clinical_data_request_test
+      id :pdex_explanationofbenefit_clinical_data_request
       title 'ExplanationOfBenefit resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type ExplanationOfBenefit

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/goal_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/goal_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientGoalSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_goal_clinical_data_request_test
+      id :pdex_goal_clinical_data_request
       title 'Goal resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Goal

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/immunization_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/immunization_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientImmunizationSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_immunization_clinical_data_request_test
+      id :pdex_immunization_clinical_data_request
       title 'Immunization resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Immunization

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/location_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/location_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientLocationSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_location_clinical_data_request_test
+      id :pdex_location_clinical_data_request
       title 'Location resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Location

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/medicationdispense_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/medicationdispense_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientMedicationDispenseSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_medicationdispense_clinical_data_request_test
+      id :pdex_medicationdispense_clinical_data_request
       title 'MedicationDispense resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type MedicationDispense

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/medicationrequest_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/medicationrequest_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientMedicationRequestSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_medicationrequest_clinical_data_request_test
+      id :pdex_medicationrequest_clinical_data_request
       title 'MedicationRequest resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type MedicationRequest

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/observation_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/observation_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientObservationSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_observation_clinical_data_request_test
+      id :pdex_observation_clinical_data_request
       title 'Observation resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Observation

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/organization_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/organization_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientOrganizationSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_organization_clinical_data_request_test
+      id :pdex_organization_clinical_data_request
       title 'Organization resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Organization

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/patient_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/patient_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientPatientSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_patient_clinical_data_request_test
+      id :pdex_patient_clinical_data_request
       title 'Patient resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Patient

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/patient_id_search_request_check_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/patient_id_search_request_check_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientPatientIdSearchRequestCheckTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_patient_id_search_request_check_test
+      id :pdex_patient_id_search_request_check
       title 'Check for Patient Id Search'
       description %(
         This test will check that a Patient search was made to get the Patient's

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/practitioner_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/practitioner_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientPractitionerSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_practitioner_clinical_data_request_test
+      id :pdex_practitioner_clinical_data_request
       title 'Practitioner resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Practitioner

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/practitionerrole_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/practitionerrole_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientPractitionerRoleSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_practitionerrole_clinical_data_request_test
+      id :pdex_practitionerrole_clinical_data_request
       title 'PractitionerRole resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type PractitionerRole

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/procedure_clinical_data_request_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/clinical_data_request_tests/procedure_clinical_data_request_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class PDexClientProcedureSubmitClinicalDataRequestTest < Inferno::Test
       include ClientValidationTest
   
-      id :pdex_procedure_clinical_data_request_test
+      id :pdex_procedure_clinical_data_request
       title 'Procedure resources related to the patient matched are gathered'
       description %(
         This test verify that the expected instances of resource type Procedure

--- a/lib/davinci_pdex_test_kit/pdex_payer_client_suite.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client_suite.rb
@@ -86,44 +86,48 @@ module DaVinciPDexTestKit
     group do
       run_as_group
       title "Workflow Tests"
+      id :payer_to_payer_workflow
 
       group do
         title "Interaction Tests"
+        id :client_workflow_interaction
 
-        test from: :pdex_client_workflow_interaction_test
+        test from: :pdex_client_workflow_interaction
       end
 
       group do
         title "$member-match validation"
+        id :member_match_validation
 
-        test from: :pdex_initial_member_match_validation_test
+        test from: :pdex_initial_member_match_validation
       end
 
       group do
         title "Clinical data request validation"
+        id :clinical_data_validation
 
-        test from: :pdex_clinical_data_request_check_test
-        test from: :pdex_patient_id_search_request_check_test
-        test from: :pdex_allergyintolerance_clinical_data_request_test
-        test from: :pdex_careplan_clinical_data_request_test
-        test from: :pdex_careteam_clinical_data_request_test
-        test from: :pdex_condition_clinical_data_request_test
-        test from: :pdex_device_clinical_data_request_test
-        test from: :pdex_diagnosticreport_clinical_data_request_test
-        test from: :pdex_documentreference_clinical_data_request_test
-        test from: :pdex_encounter_clinical_data_request_test
-        test from: :pdex_explanationofbenefit_clinical_data_request_test
-        test from: :pdex_goal_clinical_data_request_test
-        test from: :pdex_immunization_clinical_data_request_test
-        test from: :pdex_location_clinical_data_request_test
-        test from: :pdex_medicationdispense_clinical_data_request_test
-        test from: :pdex_medicationrequest_clinical_data_request_test
-        test from: :pdex_observation_clinical_data_request_test
-        test from: :pdex_organization_clinical_data_request_test
-        test from: :pdex_patient_clinical_data_request_test
-        test from: :pdex_practitioner_clinical_data_request_test
-        test from: :pdex_practitionerrole_clinical_data_request_test
-        test from: :pdex_procedure_clinical_data_request_test
+        test from: :pdex_clinical_data_request_check
+        test from: :pdex_patient_id_search_request_check
+        test from: :pdex_allergyintolerance_clinical_data_request
+        test from: :pdex_careplan_clinical_data_request
+        test from: :pdex_careteam_clinical_data_request
+        test from: :pdex_condition_clinical_data_request
+        test from: :pdex_device_clinical_data_request
+        test from: :pdex_diagnosticreport_clinical_data_request
+        test from: :pdex_documentreference_clinical_data_request
+        test from: :pdex_encounter_clinical_data_request
+        test from: :pdex_explanationofbenefit_clinical_data_request
+        test from: :pdex_goal_clinical_data_request
+        test from: :pdex_immunization_clinical_data_request
+        test from: :pdex_location_clinical_data_request
+        test from: :pdex_medicationdispense_clinical_data_request
+        test from: :pdex_medicationrequest_clinical_data_request
+        test from: :pdex_observation_clinical_data_request
+        test from: :pdex_organization_clinical_data_request
+        test from: :pdex_patient_clinical_data_request
+        test from: :pdex_practitioner_clinical_data_request
+        test from: :pdex_practitionerrole_clinical_data_request
+        test from: :pdex_procedure_clinical_data_request
       end
     end
     

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/coverage_to_link_minimal_data_validation.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/coverage_to_link_minimal_data_validation.rb
@@ -28,7 +28,7 @@ module DaVinciPDexTestKit
     #
     class CoverageToLinkMinimalDataValidation < Inferno::Test
 
-      id :pdex_coverage_to_link_minimal_data_validation
+      id :pdex_coverage_to_link_minimal_validation
       title '[USER INPUT VALIDATION] CoverageToLink parameter should not include any data elements not marked as mustSupport'
       optional
       description %{

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/coverage_to_link_must_support_validation.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/coverage_to_link_must_support_validation.rb
@@ -29,7 +29,7 @@ module DaVinciPDexTestKit
     #
     class CoverageToLinkMustSupportValidation < Inferno::Test
 
-      id :pdex_coverage_to_link_must_support_validation
+      id :pdex_coverage_to_link_ms_validation
       title '[USER INPUT VALIDATION] CoverageToLink parameter is optional for generic FHIR clients, but required for Payer systems.'
       description 'See [CoverageToLink parameter documentation](https://hl7.org/fhir/us/davinci-hrex/STU1/OperationDefinition-member-match.html).'
       optional

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
@@ -26,7 +26,7 @@ requirement of DaVinci PDex v2.0.0.
 
       )
 
-      id :pdex_eob_id_search_test
+      id :pdex_eob_id_search
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_id_search_test.rb
@@ -26,11 +26,11 @@ requirement of DaVinci PDex v2.0.0.
 
       )
 
-      id :pdex_explanation_of_benefit__id_search_test
+      id :pdex_eob_id_search_test
 
       input :patient_ids,
-        title: 'Patient IDs',
-        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
 
       # TODO: test if this test runs
 
@@ -43,7 +43,8 @@ requirement of DaVinci PDex v2.0.0.
       end
 
       def self.metadata
-        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'),
+                                                                                 aliases: true))
       end
 
       def scratch_resources

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
@@ -26,11 +26,11 @@ requirement of DaVinci PDex v2.0.0.
 
       )
 
-      id :pdex_explanation_of_benefit_identifier_search_test
+      id :pdex_eob_identifier_search_test
 
       input :patient_ids,
-        title: 'Patient IDs',
-        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
 
       # TODO: test if this test runs
 
@@ -43,7 +43,8 @@ requirement of DaVinci PDex v2.0.0.
       end
 
       def self.metadata
-        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'),
+                                                                                 aliases: true))
       end
 
       def scratch_resources

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_identifier_search_test.rb
@@ -26,7 +26,7 @@ requirement of DaVinci PDex v2.0.0.
 
       )
 
-      id :pdex_eob_identifier_search_test
+      id :pdex_eob_identifier_search
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_must_support_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_must_support_test.rb
@@ -18,14 +18,15 @@ module DaVinciPDexTestKit
         * ...
       )
 
-      id :pdex_explanation_of_benefit_must_support_test
+      id :pdex_eob_must_support_test
 
       def resource_type
         'ExplanationOfBenefit'
       end
 
       def self.metadata
-        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'),
+                                                                                 aliases: true))
       end
 
       def scratch_resources

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_must_support_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_must_support_test.rb
@@ -18,7 +18,7 @@ module DaVinciPDexTestKit
         * ...
       )
 
-      id :pdex_eob_must_support_test
+      id :pdex_eob_must_support
 
       def resource_type
         'ExplanationOfBenefit'

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_last_updated_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_last_updated_search_test.rb
@@ -32,7 +32,7 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_eob_patient_last_updated_test
+      id :pdex_eob_patient_last_updated
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_last_updated_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_last_updated_search_test.rb
@@ -32,23 +32,24 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_explanation_of_benefit_patient__last_updated_search_test
+      id :pdex_eob_patient_last_updated_test
 
       input :patient_ids,
-        title: 'Patient IDs',
-        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
-  
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+
       def self.properties
         @properties ||= USCoreTestKit::SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
           search_param_names: ['patient', '_lastUpdated'],
           test_post_search: true
-          # TODO other properties?
+          # TODO: other properties?
         )
       end
 
       def self.metadata
-        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'),
+                                                                                 aliases: true))
       end
 
       def scratch_resources

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_last_updated_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_last_updated_search_test.rb
@@ -32,7 +32,7 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_eob_patient_last_updated
+      id :pdex_eob_patient_last_updated_search
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_service_date_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_service_date_search_test.rb
@@ -32,7 +32,7 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_eob_patient_service_date
+      id :pdex_eob_patient_service_date_search
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_service_date_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_service_date_search_test.rb
@@ -32,23 +32,24 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_explanation_of_benefit_patient_service_date_search_test
+      id :pdex_eob_patient_service_date_test
 
       input :patient_ids,
-        title: 'Patient IDs',
-        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
-  
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+
       def self.properties
         @properties ||= USCoreTestKit::SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
           search_param_names: ['patient', 'service-date'],
           test_post_search: true
-          # TODO other properties?
+          # TODO: other properties?
         )
       end
 
       def self.metadata
-        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'),
+                                                                                 aliases: true))
       end
 
       def scratch_resources

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_service_date_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_service_date_search_test.rb
@@ -32,7 +32,7 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_eob_patient_service_date_test
+      id :pdex_eob_patient_service_date
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_type_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_type_search_test.rb
@@ -32,7 +32,7 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_eob_patient_type_search_test
+      id :pdex_eob_patient_type_search
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_type_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_type_search_test.rb
@@ -32,23 +32,24 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_explanation_of_benefit_patient_type_search_test
+      id :pdex_eob_patient_type_search_test
 
       input :patient_ids,
-        title: 'Patient IDs',
-        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
-  
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+
       def self.properties
         @properties ||= USCoreTestKit::SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
           search_param_names: ['patient', 'type'],
           test_post_search: true
-          # TODO other properties?
+          # TODO: other properties?
         )
       end
 
       def self.metadata
-        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'),
+                                                                                 aliases: true))
       end
 
       def scratch_resources

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_use_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_use_search_test.rb
@@ -32,12 +32,12 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_explanation_of_benefit_patient_use_search_test
+      id :pdex_eob_patient_use_search_test
 
       input :patient_ids,
-        title: 'Patient IDs',
-        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
-  
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+
       def self.properties
         @properties ||= USCoreTestKit::SearchTestProperties.new(
           first_search: true,
@@ -53,7 +53,8 @@ requirement of PDex v2.0.0.
       end
 
       def self.metadata
-        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'),
+                                                                                 aliases: true))
       end
 
       def scratch_resources

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_use_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_patient_use_search_test.rb
@@ -32,7 +32,7 @@ requirement of PDex v2.0.0.
 
       )
 
-      id :pdex_eob_patient_use_search_test
+      id :pdex_eob_patient_use_search
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_provenance_revinclude_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_provenance_revinclude_search_test.rb
@@ -15,7 +15,7 @@ module USCoreTestKit
         will pass if a Provenance resource is found in the response.
       %)
 
-      id :pdex_eob_provenance_revinclude_test
+      id :pdex_eob_provenance_revinclude
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_provenance_revinclude_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_provenance_revinclude_search_test.rb
@@ -15,7 +15,7 @@ module USCoreTestKit
         will pass if a Provenance resource is found in the response.
       %)
 
-      id :pdex_eob_provenance_revinclude
+      id :pdex_eob_provenance_revinclude_search
 
       input :patient_ids,
             title: 'Patient IDs',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_provenance_revinclude_search_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_provenance_revinclude_search_test.rb
@@ -15,16 +15,16 @@ module USCoreTestKit
         will pass if a Provenance resource is found in the response.
       %)
 
-      id :pdex_explanation_of_benefit_provenance_revinclude_search_test
-  
+      id :pdex_eob_provenance_revinclude_test
+
       input :patient_ids,
-        title: 'Patient IDs',
-        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
-  
+            title: 'Patient IDs',
+            description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+
       def properties
         @properties ||= USCoreTestKit::SearchTestProperties.new(
           resource_type: 'ExplanationOfBenefit',
-        search_param_names: ['patient']
+          search_param_names: ['patient']
         )
       end
 
@@ -33,7 +33,10 @@ module USCoreTestKit
       end
 
       def self.provenance_metadata
-        @provenance_metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, '..', 'provenance', 'metadata.yml'), aliases: true))
+        @provenance_metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(
+                                                                               File.join(__dir__, '..', 'provenance',
+                                                                                         'metadata.yml'), aliases: true
+                                                                             ))
       end
 
       def scratch_resources

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_read_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_read_test.rb
@@ -8,7 +8,7 @@ module DaVinciPDexTestKit
       title 'Server returns correct ExplanationOfBenefit resource from ExplanationOfBenefit read interaction'
       description 'A server SHALL support the ExplanationOfBenefit read interaction.'
 
-      id :pdex_eob_read_test
+      id :pdex_eob_read
 
       def resource_type
         'ExplanationOfBenefit'

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_read_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_read_test.rb
@@ -8,7 +8,7 @@ module DaVinciPDexTestKit
       title 'Server returns correct ExplanationOfBenefit resource from ExplanationOfBenefit read interaction'
       description 'A server SHALL support the ExplanationOfBenefit read interaction.'
 
-      id :pdex_explanation_of_benefit_read_test
+      id :pdex_eob_read_test
 
       def resource_type
         'ExplanationOfBenefit'

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_reference_resolution_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_reference_resolution_test.rb
@@ -28,7 +28,8 @@ module DaVinciPDexTestKit
       end
 
       def self.metadata
-        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true))
+        @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml'),
+                                                                                 aliases: true))
       end
 
       def scratch_resources

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_reference_resolution_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_reference_resolution_test.rb
@@ -21,7 +21,7 @@ module DaVinciPDexTestKit
         * ...
       )
 
-      id :pdex_explanation_of_benefit_reference_resolution
+      id :pdex_eob_ref_resolution
 
       def resource_type
         'ExplanationOfBenefit'

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_reference_resolution_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_reference_resolution_test.rb
@@ -21,7 +21,7 @@ module DaVinciPDexTestKit
         * ...
       )
 
-      id :pdex_explanation_of_benefit_reference_resolution_test
+      id :pdex_explanation_of_benefit_reference_resolution
 
       def resource_type
         'ExplanationOfBenefit'

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_validation_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_validation_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class ExplanationOfBenefitValidationTest < Inferno::Test
       include USCoreTestKit::ValidationTest
 
-      id :pdex_eob_validation_test
+      id :pdex_eob_validation
       title 'ExplanationOfBenefit resources returned during previous tests conform to the US Core ExplanationOfBenefit Profile'
       description %(
 This test verifies resources returned from the first search conform to

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_validation_test.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/explanation_of_benefit_validation_test.rb
@@ -5,7 +5,7 @@ module DaVinciPDexTestKit
     class ExplanationOfBenefitValidationTest < Inferno::Test
       include USCoreTestKit::ValidationTest
 
-      id :pdex_explanation_of_benefit_validation_test
+      id :pdex_eob_validation_test
       title 'ExplanationOfBenefit resources returned during previous tests conform to the US Core ExplanationOfBenefit Profile'
       description %(
 This test verifies resources returned from the first search conform to

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/metadata.yml
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/metadata.yml
@@ -562,30 +562,30 @@
   - http://hl7.org/fhir/R4/location
 
 :tests:
-- :id: pdex_explanation_of_benefit_patient_use_search_test
+- :id: pdex_eob_patient_use_search
   :file_name: explanation_of_benefit_patient_use_search_test.rb
-- :id: pdex_explanation_of_benefit__id_search_test
+- :id: pdex_eob_id_search
   :file_name: explanation_of_benefit_id_search_test.rb
-- :id: pdex_explanation_of_benefit_patient__last_updated_search_test
+- :id: pdex_eob_patient_last_updated
   :file_name: explanation_of_benefit_patient_last_updated_search_test.rb
-- :id: pdex_explanation_of_benefit_service_date_search_test
+- :id: pdex_eob_service_date
   :file_name: explanation_of_benefit_service_date_search_test.rb
-- :id: pdex_explanation_of_benefit_patient_type_search_test
+- :id: pdex_eob_patient_type_search
   :file_name: explanation_of_benefit_patient_type_search_test.rb
-- :id: pdex_explanation_of_benefit_identifier_search_test
+- :id: pdex_eob_identifier_search
   :file_name: explanation_of_benefit_identifier_search_test.rb
-- :id: pdex_explanation_of_benefit_read_test
+- :id: pdex_eob_read
   :file_name: explanation_of_benefit_read_test.rb
-- :id: pdex_explanation_of_benefit_provenance_revinclude_search_test
+- :id: pdex_eob_provenance_revinclude
   :file_name: explanation_of_benefit_provenance_revinclude_search_test.rb
-- :id: pdex_explanation_of_benefit_validation_test
+- :id: pdex_eob_validation
   :file_name: explanation_of_benefit_validation_test.rb
-- :id: pdex_explanation_of_benefit_must_support_test
+- :id: pdex_eob_must_support
   :file_name: explanation_of_benefit_must_support_test.rb
-- :id: pdex_explanation_of_benefit_reference_resolution_test
+- :id: pdex_eob_ref_resolution
   :file_name: explanation_of_benefit_reference_resolution_test.rb
 
-:id: pdex_explanation_of_benefit
+:id: pdex_eob
 :file_name: explanation_of_benefit_group.rb
 
 # NOTE: delayed_references is set as false above

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/metadata.yml
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit/metadata.yml
@@ -566,7 +566,7 @@
   :file_name: explanation_of_benefit_patient_use_search_test.rb
 - :id: pdex_eob_id_search
   :file_name: explanation_of_benefit_id_search_test.rb
-- :id: pdex_eob_patient_last_updated
+- :id: pdex_eob_patient_last_updated_search
   :file_name: explanation_of_benefit_patient_last_updated_search_test.rb
 - :id: pdex_eob_service_date
   :file_name: explanation_of_benefit_service_date_search_test.rb
@@ -576,7 +576,7 @@
   :file_name: explanation_of_benefit_identifier_search_test.rb
 - :id: pdex_eob_read
   :file_name: explanation_of_benefit_read_test.rb
-- :id: pdex_eob_provenance_revinclude
+- :id: pdex_eob_provenance_revinclude_search
   :file_name: explanation_of_benefit_provenance_revinclude_search_test.rb
 - :id: pdex_eob_validation
   :file_name: explanation_of_benefit_validation_test.rb

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit_group.rb
@@ -18,7 +18,7 @@ module DaVinciPDexTestKit
 
     # PDex PriorAuthorization Profile for ExplanationOfBenefit Resource Test Group
     class ExplanationOfBenefitGroup < Inferno::TestGroup
-      id :pdex_eob_group
+      id :pdex_eob
       title 'PDex Prior Authorization Tests'
       short_description 'Verify support for the server capabilities required by the PDex Prior Authorization Profile.'
       description %(
@@ -89,17 +89,17 @@ read succeeds.
         @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'explanation_of_benefit', 'metadata.yml')), aliases: true)
       end
 
-      test from: :pdex_eob_patient_use_search_test
-      test from: :pdex_eob_id_search_test
-      test from: :pdex_eob_patient_last_updated_test
-      test from: :pdex_eob_patient_service_date_test
-      test from: :pdex_eob_patient_type_search_test
-      test from: :pdex_eob_identifier_search_test
-      test from: :pdex_eob_read_test
-      test from: :pdex_eob_provenance_revinclude_test
-      test from: :pdex_eob_validation_test
-      test from: :pdex_eob_must_support_test
-      # test from: :pdex_eob_ref_resolution_test
+      test from: :pdex_eob_patient_use_search
+      test from: :pdex_eob_id_search
+      test from: :pdex_eob_patient_last_updated
+      test from: :pdex_eob_patient_service_date
+      test from: :pdex_eob_patient_type_search
+      test from: :pdex_eob_identifier_search
+      test from: :pdex_eob_read
+      test from: :pdex_eob_provenance_revinclude
+      test from: :pdex_eob_validation
+      test from: :pdex_eob_must_support
+      # test from: :pdex_eob_ref_resolution
     end
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit_group.rb
@@ -91,12 +91,12 @@ read succeeds.
 
       test from: :pdex_eob_patient_use_search
       test from: :pdex_eob_id_search
-      test from: :pdex_eob_patient_last_updated
-      test from: :pdex_eob_patient_service_date
+      test from: :pdex_eob_patient_last_updated_search
+      test from: :pdex_eob_patient_service_date_search
       test from: :pdex_eob_patient_type_search
       test from: :pdex_eob_identifier_search
       test from: :pdex_eob_read
-      test from: :pdex_eob_provenance_revinclude
+      test from: :pdex_eob_provenance_revinclude_search
       test from: :pdex_eob_validation
       test from: :pdex_eob_must_support
       # test from: :pdex_eob_ref_resolution

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/explanation_of_benefit_group.rb
@@ -18,7 +18,7 @@ module DaVinciPDexTestKit
 
     # PDex PriorAuthorization Profile for ExplanationOfBenefit Resource Test Group
     class ExplanationOfBenefitGroup < Inferno::TestGroup
-      id :pdex_explanation_of_benefit_group
+      id :pdex_eob_group
       title 'PDex Prior Authorization Tests'
       short_description 'Verify support for the server capabilities required by the PDex Prior Authorization Profile.'
       description %(
@@ -89,17 +89,17 @@ read succeeds.
         @metadata ||= USCoreTestKit::Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'explanation_of_benefit', 'metadata.yml')), aliases: true)
       end
 
-      test from: :pdex_explanation_of_benefit_patient_use_search_test
-      test from: :pdex_explanation_of_benefit__id_search_test
-      test from: :pdex_explanation_of_benefit_patient__last_updated_search_test
-      test from: :pdex_explanation_of_benefit_patient_service_date_search_test
-      test from: :pdex_explanation_of_benefit_patient_type_search_test
-      test from: :pdex_explanation_of_benefit_identifier_search_test
-      test from: :pdex_explanation_of_benefit_read_test
-      test from: :pdex_explanation_of_benefit_provenance_revinclude_search_test
-      test from: :pdex_explanation_of_benefit_validation_test
-      test from: :pdex_explanation_of_benefit_must_support_test
-      # test from: :pdex_explanation_of_benefit_reference_resolution_test
+      test from: :pdex_eob_patient_use_search_test
+      test from: :pdex_eob_id_search_test
+      test from: :pdex_eob_patient_last_updated_test
+      test from: :pdex_eob_patient_service_date_test
+      test from: :pdex_eob_patient_type_search_test
+      test from: :pdex_eob_identifier_search_test
+      test from: :pdex_eob_read_test
+      test from: :pdex_eob_provenance_revinclude_test
+      test from: :pdex_eob_validation_test
+      test from: :pdex_eob_must_support_test
+      # test from: :pdex_eob_ref_resolution_test
     end
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/export_patient_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/export_patient_group.rb
@@ -18,7 +18,7 @@ module DaVinciPDexTestKit
       description <<~DESCRIPTION
         Verify that patient level export on the Bulk Data server follow the Bulk Data Access Implementation Guide
       DESCRIPTION
-      id :pdex_patient_export_group
+      id :pdex_patient_export
       optional
 
       run_as_group
@@ -40,7 +40,7 @@ module DaVinciPDexTestKit
       output :patient_requires_access_token, :patient_status_output, :patient_bulk_download_url
 
       test from: :pdex_patient_operation_in_cap_stat_validation,
-           id: :pdex_patient_export_in_cap_stat_test,
+           id: :pdex_patient_export_in_cap_stat,
            title: 'Bulk Data Server declares support for Patient export operation in CapabilityStatement',
            config: {
              options: { operation_name: 'export', operation_url: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export' }

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/export_patient_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/export_patient_group.rb
@@ -39,8 +39,8 @@ module DaVinciPDexTestKit
 
       output :patient_requires_access_token, :patient_status_output, :patient_bulk_download_url
 
-      test from: :pdex_patient_operation_in_capability_statement_validation,
-           id: :pdex_patient_export_in_capability_statement_test,
+      test from: :pdex_patient_operation_in_cap_stat_validation,
+           id: :pdex_patient_export_in_cap_stat_test,
            title: 'Bulk Data Server declares support for Patient export operation in CapabilityStatement',
            config: {
              options: { operation_name: 'export', operation_url: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export' }

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/export_patient_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/export_patient_group.rb
@@ -39,8 +39,8 @@ module DaVinciPDexTestKit
 
       output :patient_requires_access_token, :patient_status_output, :patient_bulk_download_url
 
-      test from: :pdex_patient_operation_in_cap_stat_validation,
-           id: :pdex_patient_export_in_cap_stat,
+      test from: :pdex_patient_operation_in_cap_stmt_validation,
+           id: :pdex_patient_export_in_cap_stmt,
            title: 'Bulk Data Server declares support for Patient export operation in CapabilityStatement',
            config: {
              options: { operation_name: 'export', operation_url: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export' }

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/member_match_request_local_references_validation.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/member_match_request_local_references_validation.rb
@@ -27,7 +27,7 @@ module DaVinciPDexTestKit
     # resource. 
     #
     class MemberMatchRequestLocalReferencesValidation < Inferno::Test
-      id :pdex_member_match_request_local_references_validation
+      id :pdex_member_match_local_ref_validation
 
       title '[USER INPUT VALIDATION] Member match request only uses local references'
 

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/member_match_request_profile_validation.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/member_match_request_profile_validation.rb
@@ -29,7 +29,7 @@ module DaVinciPDexTestKit
     # resource. 
     #
     class MemberMatchRequestProfileValidation < Inferno::Test
-      id :pdex_member_match_request_profile_validation
+      id :pdex_member_match_profile_validation
 
       input :member_match_request
 

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/multiple_member_matches_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/multiple_member_matches_group.rb
@@ -8,7 +8,7 @@ module DaVinciPDexTestKit
   module PDexPayerServer
     class MultipleMemberMatchesGroup < Inferno::TestGroup
 
-        id :pdex_multiple_member_matches_group
+        id :pdex_multiple_member_matches
         title '$member-match with multiple matches'
 
         run_as_group
@@ -22,7 +22,7 @@ module DaVinciPDexTestKit
         group_config = { inputs: { member_match_request: { name: :multiple_member_match_request } } }
   
         test from: :pdex_member_match_profile_validation do
-          id :pdex_multiple_member_match_request_profile_test
+          id :pdex_multiple_member_match_request_profile
           config(group_config)
           title '[USER INPUT VALIDATION] Member match request for multiple matches is valid'
           description %{

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/multiple_member_matches_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/multiple_member_matches_group.rb
@@ -21,7 +21,7 @@ module DaVinciPDexTestKit
 
         group_config = { inputs: { member_match_request: { name: :multiple_member_match_request } } }
   
-        test from: :pdex_member_match_request_profile_validation do
+        test from: :pdex_member_match_profile_validation do
           id :pdex_multiple_member_match_request_profile_test
           config(group_config)
           title '[USER INPUT VALIDATION] Member match request for multiple matches is valid'
@@ -35,10 +35,10 @@ module DaVinciPDexTestKit
           # Inherits
         end
 
-        test from: :pdex_member_match_request_local_references_validation, config: group_config
+        test from: :pdex_member_match_local_ref_validation, config: group_config
   
-        test from: :pdex_coverage_to_link_minimal_data_validation, config: group_config
-        test from: :pdex_coverage_to_link_must_support_validation, config: group_config
+        test from: :pdex_coverage_to_link_minimal_validation, config: group_config
+        test from: :pdex_coverage_to_link_ms_validation, config: group_config
 
         test do
           id :pdex_member_match_has_multiple_matches

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/multiple_member_matches_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/multiple_member_matches_group.rb
@@ -22,7 +22,7 @@ module DaVinciPDexTestKit
         group_config = { inputs: { member_match_request: { name: :multiple_member_match_request } } }
   
         test from: :pdex_member_match_profile_validation do
-          id :pdex_multiple_member_match_request_profile
+          id :pdex_multiple_match_profile_validation
           config(group_config)
           title '[USER INPUT VALIDATION] Member match request for multiple matches is valid'
           description %{

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/no_member_matches_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/no_member_matches_group.rb
@@ -20,8 +20,8 @@ module DaVinciPDexTestKit
 
         group_config = { inputs: { member_match_request: { name: :no_member_match_request } } }
 
-        test from: :pdex_member_match_request_profile_validation do
-          id :pdex_no_member_match_request_profile_test
+        test from: :pdex_member_match_profile_validation do
+          id :pdex_no_member_match_profile_test
           config(group_config)
 
           title '[USER INPUT VALIDATION] Member match request for no matches is valid'
@@ -33,10 +33,10 @@ module DaVinciPDexTestKit
           }
         end
 
-        test from: :pdex_member_match_request_local_references_validation, config: group_config
+        test from: :pdex_member_match_local_ref_validation, config: group_config
 
-        test from: :pdex_coverage_to_link_minimal_data_validation, config: group_config
-        test from: :pdex_coverage_to_link_must_support_validation, config: group_config
+        test from: :pdex_coverage_to_link_minimal_validation, config: group_config
+        test from: :pdex_coverage_to_link_ms_validation, config: group_config
 
 
         test do

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/no_member_matches_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/no_member_matches_group.rb
@@ -21,7 +21,7 @@ module DaVinciPDexTestKit
         group_config = { inputs: { member_match_request: { name: :no_member_match_request } } }
 
         test from: :pdex_member_match_profile_validation do
-          id :pdex_no_member_match_profile
+          id :pdex_no_match_profile_validation
           config(group_config)
 
           title '[USER INPUT VALIDATION] Member match request for no matches is valid'

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/no_member_matches_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/no_member_matches_group.rb
@@ -7,7 +7,7 @@ require_relative 'coverage_to_link_must_support_validation'
 module DaVinciPDexTestKit
   module PDexPayerServer
     class NoMemberMatchesGroup < Inferno::TestGroup
-        id :pdex_no_member_matches_group
+        id :pdex_no_member_matches
         title '$member-match with no matches'
 
         run_as_group
@@ -21,7 +21,7 @@ module DaVinciPDexTestKit
         group_config = { inputs: { member_match_request: { name: :no_member_match_request } } }
 
         test from: :pdex_member_match_profile_validation do
-          id :pdex_no_member_match_profile_test
+          id :pdex_no_member_match_profile
           config(group_config)
 
           title '[USER INPUT VALIDATION] Member match request for no matches is valid'

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/patient_operation_in_capability_statement_validation.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/patient_operation_in_capability_statement_validation.rb
@@ -27,7 +27,7 @@ module DaVinciPDexTestKit
     # Requires an Inferno fhir client configured.
     #
     class PatientOperationInCapabilityStatementValidation < Inferno::Test
-      id :pdex_patient_operation_in_cap_stat_validation
+      id :pdex_patient_operation_in_cap_stmt_validation
 
       description %{
         The [CapabilityStatement](https://hl7.org/fhir/R4/capabilitystatement.html) must declare support for the

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/patient_operation_in_capability_statement_validation.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/patient_operation_in_capability_statement_validation.rb
@@ -27,7 +27,7 @@ module DaVinciPDexTestKit
     # Requires an Inferno fhir client configured.
     #
     class PatientOperationInCapabilityStatementValidation < Inferno::Test
-      id :pdex_patient_operation_in_capability_statement_validation
+      id :pdex_patient_operation_in_cap_stat_validation
 
       description %{
         The [CapabilityStatement](https://hl7.org/fhir/R4/capabilitystatement.html) must declare support for the

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_clinical_data_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_clinical_data_group.rb
@@ -3,7 +3,7 @@
 module DaVinciPDexTestKit
   module PDexPayerServer
     class WorkflowClinicalDataGroup < Inferno::TestGroup
-      id :pdex_workflow_clinical_data_group
+      id :pdex_workflow_clinical_data
       title 'Server can respond to search requests for clinical data on the matched patient'
       short_title 'Clinical data query'
       description %{

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_everything_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_everything_group.rb
@@ -27,7 +27,7 @@ module DaVinciPDexTestKit
         description: 'Manual Patient ID for testing Clinical Query and $everything $export without $member-match.',
         optional: true
 
-      test from: :pdex_patient_operation_in_capability_statement_validation,
+      test from: :pdex_patient_operation_in_cap_stat_validation,
            title: 'Server declares support for Patient everything operation in CapabilityStatement',
            config: {
              options: { operation_name: 'everything', operation_url: 'http://hl7.org/fhir/OperationDefinition/Patient-everything' }

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_everything_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_everything_group.rb
@@ -27,7 +27,7 @@ module DaVinciPDexTestKit
         description: 'Manual Patient ID for testing Clinical Query and $everything $export without $member-match.',
         optional: true
 
-      test from: :pdex_patient_operation_in_cap_stat_validation,
+      test from: :pdex_patient_operation_in_cap_stmt_validation,
            title: 'Server declares support for Patient everything operation in CapabilityStatement',
            config: {
              options: { operation_name: 'everything', operation_url: 'http://hl7.org/fhir/OperationDefinition/Patient-everything' }

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_everything_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_everything_group.rb
@@ -7,7 +7,7 @@ module DaVinciPDexTestKit
     class WorkflowEverythingGroup < Inferno::TestGroup
       title 'Server can respond to $everything requests on matched patient'
       short_title '$everything'
-      id :pdex_workflow_everything_group
+      id :pdex_workflow_everything
       optional
       description %{
         # Background

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_export_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_export_group.rb
@@ -8,7 +8,7 @@ require_relative 'export_validation_group'
 module DaVinciTestKit
   module PDexPayerServer
     class WorkflowExportGroup < Inferno::TestGroup
-      id :pdex_workflow_export_group
+      id :pdex_workflow_export
       title 'Server can respond to FHIR Bulk $export requests on the matched patient'
       short_title 'Bulk $export'
       optional
@@ -56,7 +56,7 @@ module DaVinciTestKit
         headers {'Authorization' => "Bearer #{bearer_token}"}
       end
 
-      group from: :pdex_patient_export_group
+      group from: :pdex_patient_export
 
       group from: :pdex_export_validation,
             title: 'Patient Export Validation Tests',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
@@ -43,15 +43,15 @@ module DaVinciPDexTestKit
         description: "A JSON payload for server's $member-match endpoint that has **exactly one match**",
         type: 'textarea'
 
-      test from: :pdex_patient_operation_in_cap_stat_validation,
-           id: :pdex_member_match_operation_in_cap_stat,
+      test from: :pdex_patient_operation_in_cap_stmt_validation,
+           id: :pdex_member_match_operation_in_cap_stmt,
            title: 'Server declares support for Patient member match operation in CapabilityStatement',
            config: {
              options: { operation_name: 'member-match', operation_url: 'http://hl7.org/fhir/us/davinci-hrex/OperationDefinition/member-match' }
            }
 
       test from: :pdex_member_match_profile_validation do
-        id :pdex_member_match_profile
+        id :pdex_one_match_profile_validation
         title '[USER INPUT VALIDATION] Member match request for exactly one match is valid'
         description %{
           This test validates the conformity of the user input to the

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
@@ -43,15 +43,15 @@ module DaVinciPDexTestKit
         description: "A JSON payload for server's $member-match endpoint that has **exactly one match**",
         type: 'textarea'
 
-      test from: :pdex_patient_operation_in_capability_statement_validation,
-           id: :pdex_member_match_operation_in_capability_statement_test,
+      test from: :pdex_patient_operation_in_cap_stat_validation,
+           id: :pdex_member_match_operation_in_cap_stat_test,
            title: 'Server declares support for Patient member match operation in CapabilityStatement',
            config: {
              options: { operation_name: 'member-match', operation_url: 'http://hl7.org/fhir/us/davinci-hrex/OperationDefinition/member-match' }
            }
 
-      test from: :pdex_member_match_request_profile_validation do
-        id :pdex_member_match_request_profile_test
+      test from: :pdex_member_match_profile_validation do
+        id :pdex_member_match_profile_test
         title '[USER INPUT VALIDATION] Member match request for exactly one match is valid'
         description %{
           This test validates the conformity of the user input to the
@@ -61,13 +61,13 @@ module DaVinciPDexTestKit
         }
       end
 
-      test from: :pdex_member_match_request_local_references_validation do
-        id :pdex_member_match_request_local_references_test
+      test from: :pdex_member_match_local_ref_validation do
+        id :pdex_member_match_local_ref_test
         title '[USER INPUT VALIDATION] Member match request only uses local references'
       end
 
-      test from: :pdex_coverage_to_link_minimal_data_validation
-      test from: :pdex_coverage_to_link_must_support_validation
+      test from: :pdex_coverage_to_link_minimal_validation
+      test from: :pdex_coverage_to_link_ms_validation
    
       test do
         id :pdex_member_match_on_server_test

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/workflow_member_match_group.rb
@@ -11,7 +11,7 @@ module DaVinciPDexTestKit
     class WorkflowMemberMatchGroup < Inferno::TestGroup
       title 'Server can return a matching member in response to $member-match request'
       short_title '$member-match'
-      id :pdex_workflow_member_match_group
+      id :pdex_workflow_member_match
       description %{
         # Background
 
@@ -44,14 +44,14 @@ module DaVinciPDexTestKit
         type: 'textarea'
 
       test from: :pdex_patient_operation_in_cap_stat_validation,
-           id: :pdex_member_match_operation_in_cap_stat_test,
+           id: :pdex_member_match_operation_in_cap_stat,
            title: 'Server declares support for Patient member match operation in CapabilityStatement',
            config: {
              options: { operation_name: 'member-match', operation_url: 'http://hl7.org/fhir/us/davinci-hrex/OperationDefinition/member-match' }
            }
 
       test from: :pdex_member_match_profile_validation do
-        id :pdex_member_match_profile_test
+        id :pdex_member_match_profile
         title '[USER INPUT VALIDATION] Member match request for exactly one match is valid'
         description %{
           This test validates the conformity of the user input to the
@@ -62,7 +62,7 @@ module DaVinciPDexTestKit
       end
 
       test from: :pdex_member_match_local_ref_validation do
-        id :pdex_member_match_local_ref_test
+        id :pdex_member_match_local_ref
         title '[USER INPUT VALIDATION] Member match request only uses local references'
       end
 
@@ -70,7 +70,7 @@ module DaVinciPDexTestKit
       test from: :pdex_coverage_to_link_ms_validation
    
       test do
-        id :pdex_member_match_on_server_test
+        id :pdex_member_match_on_server
         title 'Server handles $member-match operation successfully'
         description 'Server receives request `POST [baseURL]/Patient/$member-match` and returns 200'
            
@@ -85,7 +85,7 @@ module DaVinciPDexTestKit
       end
   
       test do
-        id :pdex_member_match_response_profile_test
+        id :pdex_member_match_response_profile
         title 'Server $member-match response conforms to profile'
         description %{
           The response body from the previous POST request to $member-match must be valid FHIR JSON conforming to

--- a/lib/davinci_pdex_test_kit/pdex_payer_server_suite.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server_suite.rb
@@ -127,10 +127,10 @@ module DaVinciPDexTestKit
           See the corresponding test group's description for the testing methodology of each part.
         )
 
-        group from: :pdex_workflow_member_match_group
-        group from: :pdex_workflow_clinical_data_group
-        group from: :pdex_workflow_everything_group
-        group from: :pdex_workflow_export_group
+        group from: :pdex_workflow_member_match
+        group from: :pdex_workflow_clinical_data
+        group from: :pdex_workflow_everything
+        group from: :pdex_workflow_export
       end
 
       group do
@@ -159,20 +159,20 @@ module DaVinciPDexTestKit
 
           input_order :url, :credentials, :no_member_match_request, :multiple_member_match_request
 
-          group from: :pdex_no_member_matches_group
-          group from: :pdex_multiple_member_matches_group
+          group from: :pdex_no_member_matches
+          group from: :pdex_multiple_member_matches
         end
 
         group do
           title 'PDEX Search and Read API (US Core plus additional PDex resource types)' 
           id :pdex_fhir_api_coverage
           
-          group from: :pdex_eob_group
+          group from: :pdex_eob
 
           # Import all US Core v3.1.1 groups without the Suite
           USCoreTestKit::USCoreV311::USCoreTestSuite.groups[1].groups.each do |group|
             # This prevents a second OAuth credentials box from appearing in UI
-            group(from: group.ancestors[1].id)
+            group(from: group.ancestors[1].id, id: group.ancestors[1].id.delete_prefix('us_core_v311_'))
           end
         end
       end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server_suite.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server_suite.rb
@@ -135,7 +135,7 @@ module DaVinciPDexTestKit
 
       group do
         title 'API Capability and Must Support Coverage'
-        id :api_and_must_support_coverage
+        id :api_and_ms_coverage
         
         group do
           title '$member-match failure cases'
@@ -165,9 +165,9 @@ module DaVinciPDexTestKit
 
         group do
           title 'PDEX Search and Read API (US Core plus additional PDex resource types)' 
-          id :pdex_search_and_read_api_coverage
+          id :pdex_fhir_api_coverage
           
-          group from: :pdex_explanation_of_benefit_group
+          group from: :pdex_eob_group
 
           # Import all US Core v3.1.1 groups without the Suite
           USCoreTestKit::USCoreV311::USCoreTestSuite.groups[1].groups.each do |group|


### PR DESCRIPTION
# Summary
Some PDex IDs are very long and make importing into other test kits exceed the character limit for IDs. Shortened some of the longest ones to make importing this test kit easier.

