### PR TITLE
FI-3813: Use core Must Support assertion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /data/*.db
+/data/igs/*.tgz
 /data/redis/**/*.rdb
 /data/redis/**/*.aof
 /data/redis/**/*.manifest

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,7 @@ end
 group :test do
   gem 'rack-test'
 end
+
+gem 'us_core_test_kit',
+    git: 'https://github.com/inferno-framework/us-core-test-kit.git',
+    branch: 'fi-3813-ms-assertion'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/inferno-framework/us-core-test-kit.git
+  revision: a2d417847527fe68331e2709ab92748d62559102
+  branch: fi-3813-ms-assertion
+  specs:
+    us_core_test_kit (0.11.0)
+      inferno_core (>= 0.6.6)
+      smart_app_launch_test_kit (>= 0.6.0)
+      tls_test_kit (~> 0.3.0)
+
 PATH
   remote: .
   specs:
@@ -6,7 +16,7 @@ PATH
       faraday (~> 1.10.4)
       faraday_middleware (~> 1.2.1)
       inferno_core (~> 0.6.2)
-      us_core_test_kit (~> 0.10.1)
+      us_core_test_kit (~> 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -156,7 +166,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    inferno_core (0.6.4)
+    inferno_core (0.6.7)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -289,8 +299,8 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
-    smart_app_launch_test_kit (0.5.0)
-      inferno_core (>= 0.6.2)
+    smart_app_launch_test_kit (0.6.0)
+      inferno_core (>= 0.6.3)
       json-jwt (~> 1.15.3)
       jwt (~> 2.6)
       tls_test_kit (~> 0.3.0)
@@ -323,10 +333,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
-    us_core_test_kit (0.10.1)
-      inferno_core (>= 0.6.4)
-      smart_app_launch_test_kit (>= 0.5.0)
-      tls_test_kit (~> 0.3.0)
     webmock (3.24.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -350,6 +356,7 @@ DEPENDENCIES
   rack-test
   roo (~> 2.10.1)
   rspec (~> 3.10)
+  us_core_test_kit!
   webmock (~> 3.11)
 
 BUNDLED WITH

--- a/davinci_pdex_test_kit.gemspec
+++ b/davinci_pdex_test_kit.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inferno-framework/davinci-pdex-test-kit/'
   spec.license       = 'Apache-2.0'
   spec.add_runtime_dependency 'inferno_core', '~> 0.6.2'
-  spec.add_runtime_dependency 'us_core_test_kit', '~> 0.10.1'
+  spec.add_runtime_dependency 'us_core_test_kit', '~> 0.11.0'
   spec.add_runtime_dependency 'bulk_data_test_kit', '~> 0.11.0'
   spec.add_runtime_dependency 'faraday', '~> 1.10.4'
   spec.add_runtime_dependency 'faraday_middleware', '~> 1.2.1'

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -7,7 +7,7 @@ services:
       # Negative values mean sessions never expire, 0 means sessions immediately expire
       SESSION_CACHE_DURATION: -1
     volumes:
-      - ./lib/davinci_pdex_test_kit/igs:/app/igs
+      - ./data/igs:/app/igs
       # To let the service share your local FHIR package cache,
       # uncomment the below line
       # - ~/.fhir:/home/ktor/.fhir


### PR DESCRIPTION
# Summary

Since PDex does not implement its own Must Support tests and instead imports them from US Core Test Kit, this branch points at the corresponding US Core branch for testing. **Pending US Core release after inferno-framework/us-core-test-kit#239 is merged.**

# Testing Guidance

Launch PDex server test suite and run test group 2.2 using custom input (not a preset):
 - patient ids: `85,355`
 - url: `https://inferno.healthit.gov/reference-server/r4`
 - token: `SAMPLE_TOKEN`

