### PR TITLE
server attestation tests to form style

### DIFF
--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/bulk_data_transmission_restrictions.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/bulk_data_transmission_restrictions.rb
@@ -14,20 +14,38 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@11'
 
+    input :pdex_bulk_data_transmission_restrictions_test_options,
+          title: 'Properly restricts Bulk Data transmission of individual member data',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module's use of the Bulk FHIR specification for transmission of individual member data
+              honors jurisdictional and personal privacy restrictions that are relevant to a member's health record.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_bulk_data_transmission_restrictions_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module's use of the Bulk FHIR specification for transmission of individual member data
-          honors jurisdictional and personal privacy restrictions that are relevant to a member's health record.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
-      )
+      assert pdex_bulk_data_transmission_restrictions_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_bulk_data_transmission_restrictions_test_note if pdex_bulk_data_transmission_restrictions_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/consent_failure.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/consent_failure.rb
@@ -18,23 +18,41 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@38',
                           'hl7.fhir.us.davinci-pdex_2.0.0@39'
 
+    input :pdex_member_match_consent_failure_test_options,
+          title: 'Handles consent non-compliance correctly during $member-match',
+          description: %(
+            The developer of the Health IT Module attests that during the `$member-match` operation:
+
+              - If a unique match to a member is found but the consent request cannot be honored (e.g., due to unsupported data segmentation policies), the system does not return a Patient ID in the response.
+
+              - In such cases, the system returns an HTTP 422 status code with an accompanying Operation Outcome that explains why the consent request could not be honored.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_member_match_consent_failure_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that during the `$member-match` operation:
-
-          - If a unique match to a member is found but the consent request cannot be honored (e.g., due to unsupported data segmentation policies), the system does not return a Patient ID in the response.
-
-          - In such cases, the system returns an HTTP 422 status code with an accompanying Operation Outcome that explains why the consent request could not be honored.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
-      )
+      assert pdex_member_match_consent_failure_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_member_match_consent_failure_test_note if pdex_member_match_consent_failure_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/consent_requirements.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/consent_requirements.rb
@@ -18,23 +18,41 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@40'
 
+    input :pdex_consent_requirements_test_options,
+          title: 'Assesses consent requirements',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module considers consent requirements to be met only if:
+              - Member Identity is matched
+              - Consent Policy (Everything or only Non-Sensitive data) matches the data release segmentation capabilities of the receiving payer
+              - Date period for consent is valid
+              - Payer requesting retrieval of data is matched.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_consent_requirements_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module considers consent requirements to be met only if:
-          - Member Identity is matched
-          - Consent Policy (Everything or only Non-Sensitive data) matches the data release segmentation capabilities of the receiving payer
-          - Date period for consent is valid
-          - Payer requesting retrieval of data is matched.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
-      )
+      assert pdex_consent_requirements_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_consent_requirements_test_note if pdex_consent_requirements_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/hrex_must_support.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/hrex_must_support.rb
@@ -15,21 +15,39 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@5'
 
+    input :pdex_must_support_defined_by_hrex_test_options,
+          title: 'Uses HRex Must Support definitions for HRex profiles',
+          description: %(
+            The developer of the Health IT Module attests that the system applies the definition
+              of "Must Support" as defined by the Da Vinci HRex Implementation Guide for all
+              HRex profiles referenced in PDex.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_must_support_defined_by_hrex_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the system applies the definition
-          of "Must Support" as defined by the Da Vinci HRex Implementation Guide for all
-          HRex profiles referenced in PDex.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
-      )
+      assert pdex_must_support_defined_by_hrex_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_must_support_defined_by_hrex_test_note if pdex_must_support_defined_by_hrex_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/licensing.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/licensing.rb
@@ -17,21 +17,39 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@1',
                           'hl7.fhir.us.davinci-pdex_2.0.0@2'
 
+    input :pdex_licensing_test_options,
+          title: 'Complies with licensing requirements',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module abides by the license
+              requirements for each terminology content artifact utilized within a functioning implementation and obtained
+              terminology licenses from the Third-Party IP owner for each code system and/or other specified artifact used.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_licensing_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module abides by the license
-          requirements for each terminology content artifact utilized within a functioning implementation and obtained
-          terminology licenses from the Third-Party IP owner for each code system and/or other specified artifact used.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
-      )
+      assert pdex_licensing_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_licensing_test_note if pdex_licensing_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
@@ -41,41 +41,59 @@ module DaVinciPDexTestKit
                           'hl7.fhir.us.davinci-pdex_2.0.0@25',
                           'hl7.fhir.us.davinci-pdex_2.0.0@26'
 
+    input :pdex_member_authorized_exchange_test_options,
+          title: 'Supports Payer-to-Payer member-authorized exchange',
+          description: %(
+            I attest that the Health IT Module supports Payer-to-Payer member-authorized
+              information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
+
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+              Health Plan is the Health PLan the member would like to share data to.
+
+              1. **Client Authorization Credentials**
+                  The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.
+
+              1. **Member Consent Flow**
+                  After the member authenticates to the Health IT Module's authorization server, the system presents an Authorization
+                  screen enabling the member to approve sharing with the target Health Plan.
+
+                  The Authorization process aligns with applicable privacy policy and regulations, allowing members to
+                  select what data may be shared.
+
+              4. **Token Issuance**
+                  Upon successful authorization, the Health IT Module issues an Access Token to the target Health Plan.
+                  The scopes associated with the Access Token are limited to the information and permissions authorized by the member.
+
+              6. **Refresh Token Handling**:
+                  Any Access Token subsequently issued by the Health IT Module using a Refresh Token enforces the same scope and member-specific
+                  restrictions as the original authorization.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_member_authorized_exchange_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          I attest that the Health IT Module supports Payer-to-Payer member-authorized
-          information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
-
-          The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
-          Health Plan is the Health PLan the member would like to share data to.
-
-          1. **Client Authorization Credentials**
-              The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.
-
-          1. **Member Consent Flow**
-              After the member authenticates to the Health IT Module's authorization server, the system presents an Authorization
-              screen enabling the member to approve sharing with the target Health Plan.
-
-              The Authorization process aligns with applicable privacy policy and regulations, allowing members to
-              select what data may be shared.
-
-          4. **Token Issuance**
-              Upon successful authorization, the Health IT Module issues an Access Token to the target Health Plan.
-              The scopes associated with the Access Token are limited to the information and permissions authorized by the member.
-
-          6. **Refresh Token Handling**:
-              Any Access Token subsequently issued by the Health IT Module using a Refresh Token enforces the same scope and member-specific
-              restrictions as the original authorization.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
-      )
+      assert pdex_member_authorized_exchange_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_member_authorized_exchange_test_note if pdex_member_authorized_exchange_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
@@ -30,32 +30,50 @@ module DaVinciPDexTestKit
                           'hl7.fhir.us.davinci-pdex_2.0.0@33',
                           'hl7.fhir.us.davinci-pdex_2.0.0@34'
 
+    input :pdex_payer_to_payer_mtls_options,
+          title: 'Supports mTLS for secure $member-match payer-to-payer exchange',
+          description: %(
+            I attest that the Health IT Module supports secure payer-to-payer exchange for $member-match as follows:
+
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+              Health Plan is the Health Plan the member would like to share data to.
+
+              1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.
+
+              2. **Client Registration** — Supports OAuth 2.0 Dynamic Client Registration for the target Health Plan over the mTLS-secured connection.
+
+              3. **Token Acquisition** — Accepts a Client Credentials grant request by the target Health Plan over mTLS to issue an OAuth 2.0 access
+              token for the $member-match operation.
+
+              4. **Scoped Access Token for Matched Patient** — If a Patient ID is matched, returns an OAuth 2.0 access token to the target Health Plan
+              that is scoped to that member to enable further data exchange.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_payer_to_payer_mtls_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          I attest that the Health IT Module supports secure payer-to-payer exchange for $member-match as follows:
-
-          The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
-          Health Plan is the Health Plan the member would like to share data to.
-
-          1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.
-
-          2. **Client Registration** — Supports OAuth 2.0 Dynamic Client Registration for the target Health Plan over the mTLS-secured connection.
-
-          3. **Token Acquisition** — Accepts a Client Credentials grant request by the target Health Plan over mTLS to issue an OAuth 2.0 access
-          token for the $member-match operation.
-
-          4. **Scoped Access Token for Matched Patient** — If a Patient ID is matched, returns an OAuth 2.0 access token to the target Health Plan
-          that is scoped to that member to enable further data exchange.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
-      )
+      assert pdex_payer_to_payer_mtls_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_payer_to_payer_mtls_note if pdex_payer_to_payer_mtls_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/payer_consent_compliance.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/payer_consent_compliance.rb
@@ -14,20 +14,38 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@45'
 
+    input :pdex_payer_consent_compliance_test_options,
+          title: 'Constrains response based on access permissions',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module constrains the data returned from the server to a requester
+              based upon the access permissions of the requester.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_payer_consent_compliance_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module constrains the data returned from the server to a requester
-          based upon the access permissions of the requester.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
-      )
+      assert pdex_payer_consent_compliance_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_payer_consent_compliance_test_note if pdex_payer_consent_compliance_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/prior_authorization_decisions.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/prior_authorization_decisions.rb
@@ -14,22 +14,40 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@56'
 
+    input :pdex_prior_authorization_decisions_test_options,
+          title: 'Makes available pending and active prior authorization decisions',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module makes available pending and active prior authorization decisions
+              and related clinical documentation and forms for items and services, not including prescription drugs, including the date the prior authorization was approved,
+              the date the authorization ends, as well as the units and services approved and those used to date, no later than one (1) business day after a provider initiates
+              a prior authorization for the beneficiary or there is a change of status for the prior authorization.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_prior_authorization_decisions_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module makes available pending and active prior authorization decisions
-          and related clinical documentation and forms for items and services, not including prescription drugs, including the date the prior authorization was approved,
-          the date the authorization ends, as well as the units and services approved and those used to date, no later than one (1) business day after a provider initiates
-          a prior authorization for the beneficiary or there is a change of status for the prior authorization.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
-      )
+      assert pdex_prior_authorization_decisions_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_prior_authorization_decisions_test_note if pdex_prior_authorization_decisions_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/provenance_records.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/provenance_records.rb
@@ -18,23 +18,41 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@12',
                           'hl7.fhir.us.davinci-pdex_2.0.0@13'
 
+    input :pdex_provenance_test_options,
+          title: 'Includes and generates provenance records as required',
+          description: %(
+            The developer of the Health IT Module attests that the system:
+
+              - Incorporates provenance records received as part of any FHIR data exchange.
+              - Generates provenance records for each non-Provenance resource, at a minimum identifying the
+                Health Plan as the Transmitter of the data in PDex exchanges.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_provenance_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the system:
-
-          - Incorporates provenance records received as part of any FHIR data exchange.
-          - Generates provenance records for each non-Provenance resource, at a minimum identifying the
-            Health Plan as the Transmitter of the data in PDex exchanges.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
-      )
+      assert pdex_provenance_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_provenance_test_note if pdex_provenance_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/read_and_search_hrex.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/read_and_search_hrex.rb
@@ -16,20 +16,38 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@17',
                           'hl7.fhir.us.davinci-pdex_2.0.0@18'
 
+    input :pdex_coverage_interaction_support_test_options,
+          title: 'Supports Read and Search for the HRex Coverage resource',
+          description: %(
+            I attest that the Health IT Module supports both the FHIR Read and Search
+              operations for the Coverage resource using the HRex Coverage profile.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_coverage_interaction_support_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          I attest that the Health IT Module supports both the FHIR Read and Search
-          operations for the Coverage resource using the HRex Coverage profile.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
-      )
+      assert pdex_coverage_interaction_support_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_coverage_interaction_support_test_note if pdex_coverage_interaction_support_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/resources_in_capability_statement.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/resources_in_capability_statement.rb
@@ -16,20 +16,38 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@15',
                           'hl7.fhir.us.davinci-pdex_2.0.0@19'
 
+    input :pdex_capability_statement_declaration_test_options,
+          title: 'Declares resources and operations in CapabilityStatement',
+          description: %(
+            The developer of the Health IT Module attests that all FHIR resources and operations
+              available via a FHIR API endpoint are declared in the system's CapabilityStatement.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_capability_statement_declaration_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+
+
     run do
-      identifier = SecureRandom.hex(32)
-
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that all FHIR resources and operations
-          available via a FHIR API endpoint are declared in the system's CapabilityStatement.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
-      )
+      assert pdex_capability_statement_declaration_test_options == 'true',
+             'Client application did not demonstrate correct usage of the authorization code.'
+      pass pdex_capability_statement_declaration_test_note if pdex_capability_statement_declaration_test_note.present?
     end
+
   end
 end


### PR DESCRIPTION
# Summary
Changes convert click-through attestations to form-style attestations using a script.

# Testing Guidance
- Go through client and server attestations to ensure they work as expected
- Inspect code, docs, and script to ensure that conversion to form format was effective

