### PR TITLE
removed url input from visual inspection and attestation tests.

### DIFF
--- a/lib/davinci_pdex_test_kit/pdex_payer_client_suite.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client_suite.rb
@@ -6,6 +6,8 @@ require_relative 'pdex_payer_client/mock_server'
 # require_relative 'must_support_test'
 # require_relative 'pdex_payer_client/client_validation_test'
 
+require_relative 'remove_input'
+
 require_relative 'pdex_payer_client/client_registration_group'
 require_relative 'pdex_payer_client/client_auth_smart_alca_group'
 require_relative 'pdex_payer_client/client_auth_smart_alcs_group'
@@ -189,6 +191,7 @@ module DaVinciPDexTestKit
     group from: :pdex_client_visual_inspection_and_attestation do
       optional
     end
+    RemoveInput::recursive_remove_input(groups.last, :url)
 
 
     # TODO: must support validation

--- a/lib/davinci_pdex_test_kit/pdex_payer_server_suite.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server_suite.rb
@@ -1,5 +1,7 @@
 require 'us_core_test_kit/generated/v3.1.1/us_core_test_suite'
 
+require_relative 'remove_input'
+
 require_relative 'pdex_payer_server/workflow_member_match_group'
 require_relative 'pdex_payer_server/workflow_clinical_data_group'
 require_relative 'pdex_payer_server/workflow_everything_group'
@@ -214,5 +216,6 @@ module DaVinciPDexTestKit
     group from: :pdex_server_visual_inspection_and_attestation do
       optional
     end
+    RemoveInput::recursive_remove_input(groups.last, :url)
   end
 end

--- a/lib/davinci_pdex_test_kit/remove_input.rb
+++ b/lib/davinci_pdex_test_kit/remove_input.rb
@@ -1,0 +1,10 @@
+module DaVinciPDexTestKit
+  module RemoveInput
+    module_function
+    def recursive_remove_input(runnable, input)
+      runnable.inputs.delete(input)
+      runnable.input_order.delete(input)
+      runnable.children.each { |child_runnable| recursive_remove_input(child_runnable, input) }
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Removes the url input request when running visual inspection and attestation tests

# Testing Guidance
- Open client suite
- Go to visual inspection and attestation tests
- Run tests and confirm that nothing requests a fhir url
- Repeat for server suite
