### PR TITLE
updated prompt-based attestations to form-based attestations

### DIFF
--- a/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/authentication.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/authentication.rb
@@ -16,7 +16,7 @@ module DaVinciPDexTestKit
     input :pdex_member_authentication_test_options,
           title: 'Uses recognized Health Plan credentials',
           description: %(
-            The developer of the Health IT Module attests that the system requires members to authenticate
+            I attest that the Health IT Module requires members to authenticate
                 using credentials issued or recognized by the Health Plan, such as credentials used to access
                 a member portal, and accepts only those credentials when processing member-authorized requests.
           ),

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/authentication.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/authentication.rb
@@ -16,7 +16,7 @@ module DaVinciPDexTestKit
     input :pdex_member_authentication_test_options,
           title: 'Uses recognized Health Plan credentials',
           description: %(
-            I attest that the Health IT Module requires members to authenticate
+            The developer of the Health IT Module attests that the system requires members to authenticate
                 using credentials issued or recognized by the Health Plan, such as credentials used to access
                 a member portal, and accepts only those credentials when processing member-authorized requests.
           ),

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/authentication.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/authentication.rb
@@ -13,22 +13,44 @@ module DaVinciPDexTestKit
 
       verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@10'
 
-      run do
-        identifier = SecureRandom.hex(32)
-
-        wait(
-          identifier:,
-          message: <<~MESSAGE
+    input :pdex_member_authentication_test_options,
+          title: 'Uses recognized Health Plan credentials',
+          description: %(
             I attest that the Health IT Module requires members to authenticate
+                using credentials issued or recognized by the Health Plan, such as credentials used to access
+                a member portal, and accepts only those credentials when processing member-authorized requests.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_member_authentication_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+    run do
+      assert pdex_member_authentication_test_options == 'true', %(
+        The following was not satisfied:
+
+            The Health IT Module requires members to authenticate
             using credentials issued or recognized by the Health Plan, such as credentials used to access
             a member portal, and accepts only those credentials when processing member-authorized requests.
 
-            [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+      )
+      pass pdex_member_authentication_test_note if pdex_member_authentication_test_note.present?
+    end
 
-            [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-          MESSAGE
-        )
-      end
     end
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/must_support.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/must_support.rb
@@ -17,24 +17,48 @@ module DaVinciPDexTestKit
                           'hl7.fhir.us.davinci-pdex_2.0.0@6',
                           'hl7.fhir.us.davinci-pdex_2.0.0@8'
 
-    run do
-      identifier = SecureRandom.hex(32)
+    input :pdex_client_must_support_interpretation_test_options,
+          title: 'Interprets Must Support according to US Core and HRex',
+          description: %(
+            The developer of the Health IT Module attests that:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that:
+              - For US Core profiles, Must Support elements are interpreted according to the US Core IG.
+              - For HRex profiles, Must Support elements are interpreted according to the HRex IG.
+              - For PDex profiles, Must Support elements are interpreted according to the US Core IG.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_client_must_support_interpretation_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+    run do
+      assert pdex_client_must_support_interpretation_test_options == 'true', %(
+        The following was not satisfied:
+
+          The Health IT Module applies Must Support rules for all profiles it implements as follows:
 
           - For US Core profiles, Must Support elements are interpreted according to the US Core IG.
           - For HRex profiles, Must Support elements are interpreted according to the HRex IG.
           - For PDex profiles, Must Support elements are interpreted according to the US Core IG.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
       )
+      pass pdex_client_must_support_interpretation_test_note if pdex_client_must_support_interpretation_test_note.present?
     end
+
   end
 end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/provenance.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/provenance.rb
@@ -15,7 +15,7 @@ module DaVinciPDexTestKit
     input :pdex_accept_retain_provenance_test_options,
           title: 'Accepts and retains Provenance in member-authorized payer-to-payer exchange',
           description: %(
-            I attest that the Health IT Module accepts and retains
+            The developer of the Health IT Module attests that the system accepts and retains
                 Provenance records received with data as part of a member-authorized payer-to-payer exchange.
           ),
           type: 'radio',

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/provenance.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/provenance.rb
@@ -15,7 +15,7 @@ module DaVinciPDexTestKit
     input :pdex_accept_retain_provenance_test_options,
           title: 'Accepts and retains Provenance in member-authorized payer-to-payer exchange',
           description: %(
-            The developer of the Health IT Module attests that the system accepts and retains
+            I attest that the Health IT Module accepts and retains
                 Provenance records received with data as part of a member-authorized payer-to-payer exchange.
           ),
           type: 'radio',

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/provenance.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/provenance.rb
@@ -12,21 +12,42 @@ module DaVinciPDexTestKit
 
       verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@28'
 
-      run do
-        identifier = SecureRandom.hex(32)
-
-        wait(
-          identifier:,
-          message: <<~MESSAGE
+    input :pdex_accept_retain_provenance_test_options,
+          title: 'Accepts and retains Provenance in member-authorized payer-to-payer exchange',
+          description: %(
             I attest that the Health IT Module accepts and retains
+                Provenance records received with data as part of a member-authorized payer-to-payer exchange.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_accept_retain_provenance_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+    run do
+      assert pdex_accept_retain_provenance_test_options == 'true', %(
+        The following was not satisfied:
+
+            The Health IT Module accepts and retains
             Provenance records received with data as part of a member-authorized payer-to-payer exchange.
 
-            [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+      )
+      pass pdex_accept_retain_provenance_test_note if pdex_accept_retain_provenance_test_note.present?
+    end
 
-            [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-          MESSAGE
-        )
-      end
     end
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/receive_must_support.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_client/visual_inspection_and_attestation/receive_must_support.rb
@@ -13,22 +13,44 @@ module DaVinciPDexTestKit
 
       verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@53'
 
-      run do
-        identifier = SecureRandom.hex(32)
-
-        wait(
-          identifier:,
-          message: <<~MESSAGE
+    input :pdex_must_support_sub_element_handling_test_options,
+          title: 'Accepts Must Support elements without error',
+          description: %(
             The developer of the Health IT Module attests that the Health IT System can accept sub-elements marked Must Support
+                without generating errors — unless those sub-elements belong to a parent element
+                that has a minimum cardinality of 0 and no Must Support flag.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_must_support_sub_element_handling_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+    run do
+      assert pdex_must_support_sub_element_handling_test_options == 'true', %(
+        The following was not satisfied:
+
+            The Health IT Module ensures that it can accept sub-elements marked Must Support
             without generating errors — unless those sub-elements belong to a parent element
             that has a minimum cardinality of 0 and no Must Support flag.
 
-            [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
+      )
+      pass pdex_must_support_sub_element_handling_test_note if pdex_must_support_sub_element_handling_test_note.present?
+    end
 
-            [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-          MESSAGE
-        )
-      end
     end
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/bulk_data_transmission_restrictions.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/bulk_data_transmission_restrictions.rb
@@ -14,20 +14,40 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@11'
 
+    input :pdex_bulk_data_transmission_restrictions_test_options,
+          title: 'Properly restricts Bulk Data transmission of individual member data',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module's use of the Bulk FHIR specification for transmission of individual member data
+              honors jurisdictional and personal privacy restrictions that are relevant to a member's health record.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_bulk_data_transmission_restrictions_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
     run do
-      identifier = SecureRandom.hex(32)
+      assert pdex_bulk_data_transmission_restrictions_test_options == 'true', %(
+        The following was not satisfied:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module's use of the Bulk FHIR specification for transmission of individual member data
-          honors jurisdictional and personal privacy restrictions that are relevant to a member's health record.
+          The Health IT Module's use of the Bulk FHIR specification for transmission of individual member data honors jurisdictional and personal privacy restrictions.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
       )
+      pass pdex_bulk_data_transmission_restrictions_test_note if pdex_bulk_data_transmission_restrictions_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/consent_failure.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/consent_failure.rb
@@ -18,23 +18,45 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@38',
                           'hl7.fhir.us.davinci-pdex_2.0.0@39'
 
+    input :pdex_member_match_consent_failure_test_options,
+          title: 'Handles consent non-compliance correctly during $member-match',
+          description: %(
+            The developer of the Health IT Module attests that during the `$member-match` operation:
+
+              - If a unique match to a member is found but the consent request cannot be honored (e.g., due to unsupported data segmentation policies), the system does not return a Patient ID in the response.
+
+              - In such cases, the system returns an HTTP 422 status code with an accompanying Operation Outcome that explains why the consent request could not be honored.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_member_match_consent_failure_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
     run do
-      identifier = SecureRandom.hex(32)
+      assert pdex_member_match_consent_failure_test_options == 'true', %(
+        The following was not satisfied:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that during the `$member-match` operation:
+          The Health IT Module correctly handles situations where during the `$member-match` operation:
+              - If a unique match to a member is found but the consent request cannot be honored (e.g., due to unsupported data segmentation policies), the system does not return a Patient ID in the response.
+              - In such cases, the system returns an HTTP 422 status code with an accompanying Operation Outcome that explains why the consent request could not be honored.
 
-          - If a unique match to a member is found but the consent request cannot be honored (e.g., due to unsupported data segmentation policies), the system does not return a Patient ID in the response.
-
-          - In such cases, the system returns an HTTP 422 status code with an accompanying Operation Outcome that explains why the consent request could not be honored.
-
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
       )
+      pass pdex_member_match_consent_failure_test_note if pdex_member_match_consent_failure_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/consent_requirements.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/consent_requirements.rb
@@ -18,23 +18,47 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@40'
 
-    run do
-      identifier = SecureRandom.hex(32)
+    input :pdex_consent_requirements_test_options,
+          title: 'Assesses consent requirements',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module considers consent requirements to be met only if:
+              - Member Identity is matched
+              - Consent Policy (Everything or only Non-Sensitive data) matches the data release segmentation capabilities of the receiving payer
+              - Date period for consent is valid
+              - Payer requesting retrieval of data is matched.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_consent_requirements_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module considers consent requirements to be met only if:
+    run do
+      assert pdex_consent_requirements_test_options == 'true', %(
+        The following was not satisfied:
+
+          The Health IT Module considers consent requirements to be met only if:
           - Member Identity is matched
           - Consent Policy (Everything or only Non-Sensitive data) matches the data release segmentation capabilities of the receiving payer
           - Date period for consent is valid
           - Payer requesting retrieval of data is matched.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
       )
+      pass pdex_consent_requirements_test_note if pdex_consent_requirements_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/hrex_must_support.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/hrex_must_support.rb
@@ -15,21 +15,42 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@5'
 
+    input :pdex_must_support_defined_by_hrex_test_options,
+          title: 'Uses HRex Must Support definitions for HRex profiles',
+          description: %(
+            The developer of the Health IT Module attests that the system applies the definition
+              of "Must Support" as defined by the Da Vinci HRex Implementation Guide for all
+              HRex profiles referenced in PDex.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_must_support_defined_by_hrex_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
     run do
-      identifier = SecureRandom.hex(32)
+      assert pdex_must_support_defined_by_hrex_test_options == 'true', %(
+        The following was not satisfied:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the system applies the definition
-          of "Must Support" as defined by the Da Vinci HRex Implementation Guide for all
-          HRex profiles referenced in PDex.
+          The Health IT Module applies the definition of "Must Support" as defined
+          by the Da Vinci HRex Implementation Guide for all HRex profiles referenced in PDex.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
       )
+      pass pdex_must_support_defined_by_hrex_test_note if pdex_must_support_defined_by_hrex_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/licensing.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/licensing.rb
@@ -17,21 +17,43 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@1',
                           'hl7.fhir.us.davinci-pdex_2.0.0@2'
 
-    run do
-      identifier = SecureRandom.hex(32)
+    input :pdex_licensing_test_options,
+          title: 'Complies with licensing requirements',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module abides by the license
+              requirements for each terminology content artifact utilized within a functioning implementation and obtained
+              terminology licenses from the Third-Party IP owner for each code system and/or other specified artifact used.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_licensing_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module abides by the license
+    run do
+      assert pdex_licensing_test_options == 'true', %(
+        The following was not satisfied:
+
+          The Health IT Module abides by the license
           requirements for each terminology content artifact utilized within a functioning implementation and obtained
           terminology licenses from the Third-Party IP owner for each code system and/or other specified artifact used.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
       )
+      pass pdex_licensing_test_note if pdex_licensing_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
@@ -47,8 +47,8 @@ module DaVinciPDexTestKit
             I attest that the Health IT Module supports Payer-to-Payer member-authorized
               information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
 
-              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
-              Health Plan is the Health PLan the member would like to share data to.
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
+              Health Plan is the Health plan the member would like to share data to.
 
               1. **Client Authorization Credentials**
                   The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.
@@ -95,7 +95,7 @@ module DaVinciPDexTestKit
           information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
 
           The Health IT Module is acting as the **source** Health Plan, and is the Health Plan the member would like to get data from.
-          The **target** Health Plan is the Health PLan the member would like to share data to.
+          The **target** Health Plan is the Health plan the member would like to share data to.
 
           1. **Client Authorization Credentials**
               The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
@@ -44,11 +44,11 @@ module DaVinciPDexTestKit
     input :pdex_member_authorized_exchange_test_options,
           title: 'Supports Payer-to-Payer member-authorized exchange',
           description: %(
-            I attest that the Health IT Module supports Payer-to-Payer member-authorized
+            The developer of the Health IT Module attests that the system supports Payer-to-Payer member-authorized
               information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
 
-              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
-              Health Plan is the Health PLan the member would like to share data to.
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
+              Health Plan is the Health Plan the member would like to share data to.
 
               1. **Client Authorization Credentials**
                   The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.
@@ -95,7 +95,7 @@ module DaVinciPDexTestKit
           information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
 
           The Health IT Module is acting as the **source** Health Plan, and is the Health Plan the member would like to get data from.
-          The **target** Health Plan is the Health PLan the member would like to share data to.
+          The **target** Health Plan is the Health Plan the member would like to share data to.
 
           1. **Client Authorization Credentials**
               The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
@@ -11,7 +11,7 @@ module DaVinciPDexTestKit
       information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
 
       The Health IT Module is acting as the **source** Health Plan, and is the Health Plan the member would like to get data from.
-      The **target** Health Plan is the Health PLan the member would like to share data to.
+      The **target** Health Plan is the Health Plan the member would like to share data to.
 
       1. **Client Authorization Credentials**
           The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
@@ -44,11 +44,11 @@ module DaVinciPDexTestKit
     input :pdex_member_authorized_exchange_test_options,
           title: 'Supports Payer-to-Payer member-authorized exchange',
           description: %(
-            The developer of the Health IT Module attests that the system supports Payer-to-Payer member-authorized
+            I attest that the Health IT Module supports Payer-to-Payer member-authorized
               information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
 
-              The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
-              Health Plan is the Health Plan the member would like to share data to.
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+              Health Plan is the Health PLan the member would like to share data to.
 
               1. **Client Authorization Credentials**
                   The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.
@@ -95,7 +95,7 @@ module DaVinciPDexTestKit
           information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
 
           The Health IT Module is acting as the **source** Health Plan, and is the Health Plan the member would like to get data from.
-          The **target** Health Plan is the Health Plan the member would like to share data to.
+          The **target** Health Plan is the Health PLan the member would like to share data to.
 
           1. **Client Authorization Credentials**
               The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/member_auth.rb
@@ -41,17 +41,61 @@ module DaVinciPDexTestKit
                           'hl7.fhir.us.davinci-pdex_2.0.0@25',
                           'hl7.fhir.us.davinci-pdex_2.0.0@26'
 
-    run do
-      identifier = SecureRandom.hex(32)
+    input :pdex_member_authorized_exchange_test_options,
+          title: 'Supports Payer-to-Payer member-authorized exchange',
+          description: %(
+            I attest that the Health IT Module supports Payer-to-Payer member-authorized
+              information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          I attest that the Health IT Module supports Payer-to-Payer member-authorized
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+              Health Plan is the Health PLan the member would like to share data to.
+
+              1. **Client Authorization Credentials**
+                  The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.
+
+              1. **Member Consent Flow**
+                  After the member authenticates to the Health IT Module's authorization server, the system presents an Authorization
+                  screen enabling the member to approve sharing with the target Health Plan.
+
+                  The Authorization process aligns with applicable privacy policy and regulations, allowing members to
+                  select what data may be shared.
+
+              4. **Token Issuance**
+                  Upon successful authorization, the Health IT Module issues an Access Token to the target Health Plan.
+                  The scopes associated with the Access Token are limited to the information and permissions authorized by the member.
+
+              6. **Refresh Token Handling**:
+                  Any Access Token subsequently issued by the Health IT Module using a Refresh Token enforces the same scope and member-specific
+                  restrictions as the original authorization.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_member_authorized_exchange_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+    run do
+      assert pdex_member_authorized_exchange_test_options == 'true', %(
+        The following was not satisfied:
+
+          The Health IT Module supports Payer-to-Payer member-authorized
           information exchange using SMART on FHIR and OAuth 2.0 by satisfying the following criteria.
 
-          The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
-          Health Plan is the Health PLan the member would like to share data to.
+          The Health IT Module is acting as the **source** Health Plan, and is the Health Plan the member would like to get data from.
+          The **target** Health Plan is the Health PLan the member would like to share data to.
 
           1. **Client Authorization Credentials**
               The Health IT Module issues the target Health Plan OAuth 2.0 client application credentials during client registration.
@@ -71,11 +115,9 @@ module DaVinciPDexTestKit
               Any Access Token subsequently issued by the Health IT Module using a Refresh Token enforces the same scope and member-specific
               restrictions as the original authorization.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
       )
+      pass pdex_member_authorized_exchange_test_note if pdex_member_authorized_exchange_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
@@ -33,9 +33,9 @@ module DaVinciPDexTestKit
     input :pdex_payer_to_payer_mtls_options,
           title: 'Supports mTLS for secure $member-match payer-to-payer exchange',
           description: %(
-            I attest that the Health IT Module supports secure payer-to-payer exchange for $member-match as follows:
+            The developer of the Health IT Module attests that the system supports secure payer-to-payer exchange for $member-match as follows:
 
-              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
               Health Plan is the Health Plan the member would like to share data to.
 
               1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.
@@ -73,7 +73,7 @@ module DaVinciPDexTestKit
 
           The Health IT Module attests that the system supports secure payer-to-payer exchange for $member-match as follows:
 
-          The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+          The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
           Health Plan is the Health Plan the member would like to share data to.
 
           1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
@@ -33,9 +33,9 @@ module DaVinciPDexTestKit
     input :pdex_payer_to_payer_mtls_options,
           title: 'Supports mTLS for secure $member-match payer-to-payer exchange',
           description: %(
-            The developer of the Health IT Module attests that the system supports secure payer-to-payer exchange for $member-match as follows:
+            I attest that the Health IT Module supports secure payer-to-payer exchange for $member-match as follows:
 
-              The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
               Health Plan is the Health Plan the member would like to share data to.
 
               1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.
@@ -73,7 +73,7 @@ module DaVinciPDexTestKit
 
           The Health IT Module attests that the system supports secure payer-to-payer exchange for $member-match as follows:
 
-          The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
+          The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
           Health Plan is the Health Plan the member would like to share data to.
 
           1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
@@ -9,7 +9,7 @@ module DaVinciPDexTestKit
     description <<~DESCRIPTION
       The Health IT Module attests that the system supports secure payer-to-payer exchange for $member-match as follows:
 
-      The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+      The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
       Health Plan is the Health Plan the member would like to share data to.
 
       1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.
@@ -35,7 +35,7 @@ module DaVinciPDexTestKit
           description: %(
             I attest that the Health IT Module supports secure payer-to-payer exchange for $member-match as follows:
 
-              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
               Health Plan is the Health Plan the member would like to share data to.
 
               1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.
@@ -73,7 +73,7 @@ module DaVinciPDexTestKit
 
           The Health IT Module attests that the system supports secure payer-to-payer exchange for $member-match as follows:
 
-          The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+          The **source** Health Plan is the Health Plan the member would like to get data from, and the **target**
           Health Plan is the Health Plan the member would like to share data to.
 
           1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/mtls.rb
@@ -30,13 +30,48 @@ module DaVinciPDexTestKit
                           'hl7.fhir.us.davinci-pdex_2.0.0@33',
                           'hl7.fhir.us.davinci-pdex_2.0.0@34'
 
-    run do
-      identifier = SecureRandom.hex(32)
+    input :pdex_payer_to_payer_mtls_options,
+          title: 'Supports mTLS for secure $member-match payer-to-payer exchange',
+          description: %(
+            I attest that the Health IT Module supports secure payer-to-payer exchange for $member-match as follows:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          I attest that the Health IT Module supports secure payer-to-payer exchange for $member-match as follows:
+              The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
+              Health Plan is the Health Plan the member would like to share data to.
+
+              1. **Secure mTLS Connection** — Establishes a mutual TLS (mTLS) connection with the target Health Plan.
+
+              2. **Client Registration** — Supports OAuth 2.0 Dynamic Client Registration for the target Health Plan over the mTLS-secured connection.
+
+              3. **Token Acquisition** — Accepts a Client Credentials grant request by the target Health Plan over mTLS to issue an OAuth 2.0 access
+              token for the $member-match operation.
+
+              4. **Scoped Access Token for Matched Patient** — If a Patient ID is matched, returns an OAuth 2.0 access token to the target Health Plan
+              that is scoped to that member to enable further data exchange.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_payer_to_payer_mtls_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
+    run do
+      assert pdex_payer_to_payer_mtls_options == 'true', %(
+        The following was not satisfied:
+
+          The Health IT Module attests that the system supports secure payer-to-payer exchange for $member-match as follows:
 
           The **source** Health Plan is the Health Plan the member would like to get data from, and the **etarget**
           Health Plan is the Health Plan the member would like to share data to.
@@ -51,11 +86,9 @@ module DaVinciPDexTestKit
           4. **Scoped Access Token for Matched Patient** — If a Patient ID is matched, returns an OAuth 2.0 access token to the target Health Plan
           that is scoped to that member to enable further data exchange.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
       )
+      pass pdex_payer_to_payer_mtls_note if pdex_payer_to_payer_mtls_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/payer_consent_compliance.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/payer_consent_compliance.rb
@@ -14,20 +14,40 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@45'
 
+    input :pdex_payer_consent_compliance_test_options,
+          title: 'Constrains response based on access permissions',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module constrains the data returned from the server to a requester
+              based upon the access permissions of the requester.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_payer_consent_compliance_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
     run do
-      identifier = SecureRandom.hex(32)
+      assert pdex_payer_consent_compliance_test_options == 'true', %(
+        The following was not satisfied:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module constrains the data returned from the server to a requester
-          based upon the access permissions of the requester.
+          The Health IT Module constrains the data returned from the server to a requester based upon the access permissions of the requester.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
       )
+      pass pdex_payer_consent_compliance_test_note if pdex_payer_consent_compliance_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/prior_authorization_decisions.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/prior_authorization_decisions.rb
@@ -14,22 +14,42 @@ module DaVinciPDexTestKit
 
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@56'
 
+    input :pdex_prior_authorization_decisions_test_options,
+          title: 'Makes available pending and active prior authorization decisions',
+          description: %(
+            The developer of the Health IT Module attests that the Health IT Module makes available pending and active prior authorization decisions
+              and related clinical documentation and forms for items and services, not including prescription drugs, including the date the prior authorization was approved,
+              the date the authorization ends, as well as the units and services approved and those used to date, no later than one (1) business day after a provider initiates
+              a prior authorization for the beneficiary or there is a change of status for the prior authorization.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_prior_authorization_decisions_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
     run do
-      identifier = SecureRandom.hex(32)
+      assert pdex_prior_authorization_decisions_test_options == 'true', %(
+        The following was not satisfied:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the Health IT Module makes available pending and active prior authorization decisions
-          and related clinical documentation and forms for items and services, not including prescription drugs, including the date the prior authorization was approved,
-          the date the authorization ends, as well as the units and services approved and those used to date, no later than one (1) business day after a provider initiates
-          a prior authorization for the beneficiary or there is a change of status for the prior authorization.
+          The Health IT Module makes available pending and active prior authorization decisions and related clinical documentation and forms for items and services.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** this requirement.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** this requirement.
-        MESSAGE
       )
+      pass pdex_prior_authorization_decisions_test_note if pdex_prior_authorization_decisions_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/provenance_records.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/provenance_records.rb
@@ -18,23 +18,46 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@12',
                           'hl7.fhir.us.davinci-pdex_2.0.0@13'
 
+    input :pdex_provenance_test_options,
+          title: 'Includes and generates provenance records as required',
+          description: %(
+            The developer of the Health IT Module attests that the system:
+
+              - Incorporates provenance records received as part of any FHIR data exchange.
+              - Generates provenance records for each non-Provenance resource, at a minimum identifying the
+                Health Plan as the Transmitter of the data in PDex exchanges.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_provenance_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
     run do
-      identifier = SecureRandom.hex(32)
+      assert pdex_provenance_test_options == 'true', %(
+        The following was not satisfied:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that the system:
-
+          The Health IT Module
           - Incorporates provenance records received as part of any FHIR data exchange.
           - Generates provenance records for each non-Provenance resource, at a minimum identifying the
             Health Plan as the Transmitter of the data in PDex exchanges.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
       )
+      pass pdex_provenance_test_note if pdex_provenance_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/read_and_search_hrex.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/read_and_search_hrex.rb
@@ -19,7 +19,7 @@ module DaVinciPDexTestKit
     input :pdex_coverage_interaction_support_test_options,
           title: 'Supports Read and Search for the HRex Coverage resource',
           description: %(
-            The developer of the Health IT Module attests that the system supports both the FHIR Read and Search
+            I attest that the Health IT Module supports both the FHIR Read and Search
               operations for the Coverage resource using the HRex Coverage profile.
           ),
           type: 'radio',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/read_and_search_hrex.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/read_and_search_hrex.rb
@@ -16,20 +16,41 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@17',
                           'hl7.fhir.us.davinci-pdex_2.0.0@18'
 
+    input :pdex_coverage_interaction_support_test_options,
+          title: 'Supports Read and Search for the HRex Coverage resource',
+          description: %(
+            I attest that the Health IT Module supports both the FHIR Read and Search
+              operations for the Coverage resource using the HRex Coverage profile.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_coverage_interaction_support_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
     run do
-      identifier = SecureRandom.hex(32)
+      assert pdex_coverage_interaction_support_test_options == 'true', %(
+        The following was not satisfied:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          I attest that the Health IT Module supports both the FHIR Read and Search
-          operations for the Coverage resource using the HRex Coverage profile.
+          The Health IT Module supports the FHIR Read and Search operations for the Coverage resource,
+          using the HRex Coverage profile.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
       )
+      pass pdex_coverage_interaction_support_test_note if pdex_coverage_interaction_support_test_note.present?
     end
+
   end
 end

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/read_and_search_hrex.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/read_and_search_hrex.rb
@@ -19,7 +19,7 @@ module DaVinciPDexTestKit
     input :pdex_coverage_interaction_support_test_options,
           title: 'Supports Read and Search for the HRex Coverage resource',
           description: %(
-            I attest that the Health IT Module supports both the FHIR Read and Search
+            The developer of the Health IT Module attests that the system supports both the FHIR Read and Search
               operations for the Coverage resource using the HRex Coverage profile.
           ),
           type: 'radio',

--- a/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/resources_in_capability_statement.rb
+++ b/lib/davinci_pdex_test_kit/pdex_payer_server/visual_inspection_and_attestation/resources_in_capability_statement.rb
@@ -16,20 +16,41 @@ module DaVinciPDexTestKit
     verifies_requirements 'hl7.fhir.us.davinci-pdex_2.0.0@15',
                           'hl7.fhir.us.davinci-pdex_2.0.0@19'
 
+    input :pdex_capability_statement_declaration_test_options,
+          title: 'Declares resources and operations in CapabilityStatement',
+          description: %(
+            The developer of the Health IT Module attests that all FHIR resources and operations
+              available via a FHIR API endpoint are declared in the system's CapabilityStatement.
+          ),
+          type: 'radio',
+          default: 'false',
+          options: {
+            list_options: [
+              {
+                label: 'Yes',
+                value: 'true'
+              },
+              {
+                label: 'No',
+                value: 'false'
+              }
+            ]
+          }
+    input :pdex_capability_statement_declaration_test_note,
+          title: 'Notes, if applicable:',
+          type: 'textarea',
+          optional: true
+
     run do
-      identifier = SecureRandom.hex(32)
+      assert pdex_capability_statement_declaration_test_options == 'true', %(
+        The following was not satisfied:
 
-      wait(
-        identifier:,
-        message: <<~MESSAGE
-          The developer of the Health IT Module attests that all FHIR resources and operations
-          available via a FHIR API endpoint are declared in the system's CapabilityStatement.
+          The Health IT Module declares all FHIR resources and operations available via its API
+          in its FHIR CapabilityStatement, in accordance with PDex requirements.
 
-          [Click here](#{resume_pass_url}?token=#{identifier}) if the system **meets** these requirements.
-
-          [Click here](#{resume_fail_url}?token=#{identifier}) if the system **does not meet** these requirements.
-        MESSAGE
       )
+      pass pdex_capability_statement_declaration_test_note if pdex_capability_statement_declaration_test_note.present?
     end
+
   end
 end


### PR DESCRIPTION
# Summary
Changes convert click-through attestations to form-style attestations using a script.

# Testing Guidance
- Go through client and server attestations to ensure they work as expected
- Inspect code, docs, and script to ensure that conversion to form format was effective